### PR TITLE
#50 get all user in cafe

### DIFF
--- a/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
@@ -3,10 +3,11 @@ package com.coffee.backend.domain.cafe.controller;
 
 import com.coffee.backend.domain.auth.controller.AuthenticationPrincipal;
 import com.coffee.backend.domain.cafe.dto.CafeDto;
+import com.coffee.backend.domain.cafe.dto.CafeUserProfileDto;
 import com.coffee.backend.domain.cafe.service.CafePublisher;
 import com.coffee.backend.domain.cafe.service.CafeService;
 import com.coffee.backend.domain.user.entity.User;
-import java.util.Set;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +36,7 @@ public class CafeController {
 
     //TODO : cafeId를 입력으로 받아서 특정 카페에 속한 모든 유저들을 redis에서 찾아 프론트로 넘긴다.
     @GetMapping("/cafe/{cafeId}") //http://localhost:8080/cafe/1
-    public ResponseEntity<Set<Object>> getCafeUsers(@PathVariable String cafeId) {
+    public ResponseEntity<List<CafeUserProfileDto>> getCafeUsers(@PathVariable String cafeId) {
         System.out.println("cafeId = " + cafeId);
         return ResponseEntity.ok(cafeService.getUsersByCafeId(cafeId));
     }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
@@ -37,8 +37,9 @@ public class CafeController {
     }
 
     // 특정 카페에 속한 모든 유저들을 redis에서 찾아 각 유저 정보를 조회해 프론트로 보낸다.
-    @GetMapping("/cafe/{cafeId}") //http://localhost:8080/cafe/1
-    public ResponseEntity<List<CafeUserProfileDto>> getCafeUsers(@PathVariable String cafeId) {
+    @GetMapping("/cafe/{cafeId}") //http://localhost:8080/cafe/starbucks
+    public ResponseEntity<List<CafeUserProfileDto>> getCafeUsers(@AuthenticationPrincipal User user,
+                                                                 @PathVariable String cafeId) {
         return ResponseEntity.ok(cafeService.getUserProfilesFromRedisAndDB(cafeId));
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
@@ -4,18 +4,24 @@ package com.coffee.backend.domain.cafe.controller;
 import com.coffee.backend.domain.auth.controller.AuthenticationPrincipal;
 import com.coffee.backend.domain.cafe.dto.CafeDto;
 import com.coffee.backend.domain.cafe.service.CafePublisher;
+import com.coffee.backend.domain.cafe.service.CafeService;
 import com.coffee.backend.domain.user.entity.User;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @RequiredArgsConstructor
 @Controller
 @Slf4j
 public class CafeController {
     private final CafePublisher cafePublisher;
+    private final CafeService cafeService;
 
     /*
     클라이언트에서 서버로 메시지 전송
@@ -26,4 +32,12 @@ public class CafeController {
         log.info("Message Catch!!");
         cafePublisher.updateCafeChoice(dto);
     }
+
+    //TODO : cafeId를 입력으로 받아서 특정 카페에 속한 모든 유저들을 redis에서 찾아 프론트로 넘긴다.
+    @GetMapping("/cafe/{cafeId}") //http://localhost:8080/cafe/1
+    public ResponseEntity<Set<Object>> getCafeUsers(@PathVariable String cafeId) {
+        System.out.println("cafeId = " + cafeId);
+        return ResponseEntity.ok(cafeService.getUsersByCafeId(cafeId));
+    }
+
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
@@ -7,6 +7,7 @@ import com.coffee.backend.domain.cafe.dto.CafeUserProfileDto;
 import com.coffee.backend.domain.cafe.service.CafePublisher;
 import com.coffee.backend.domain.cafe.service.CafeService;
 import com.coffee.backend.domain.user.entity.User;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +30,8 @@ public class CafeController {
     /pub/cafe/update로 메시지 발행
     */
     @MessageMapping("/cafe/update")
-    public void sendMatchRequest(@AuthenticationPrincipal User user, @Payload CafeDto dto) {
+    public void sendMatchRequest(@AuthenticationPrincipal User user, @Payload CafeDto dto)
+            throws JsonProcessingException {
         log.info("Message Catch!!");
         cafePublisher.updateCafeChoice(dto);
     }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/controller/CafeController.java
@@ -34,11 +34,9 @@ public class CafeController {
         cafePublisher.updateCafeChoice(dto);
     }
 
-    //TODO : cafeId를 입력으로 받아서 특정 카페에 속한 모든 유저들을 redis에서 찾아 프론트로 넘긴다.
+    // 특정 카페에 속한 모든 유저들을 redis에서 찾아 각 유저 정보를 조회해 프론트로 보낸다.
     @GetMapping("/cafe/{cafeId}") //http://localhost:8080/cafe/1
     public ResponseEntity<List<CafeUserProfileDto>> getCafeUsers(@PathVariable String cafeId) {
-        System.out.println("cafeId = " + cafeId);
-        return ResponseEntity.ok(cafeService.getUsersByCafeId(cafeId));
+        return ResponseEntity.ok(cafeService.getUserProfilesFromRedisAndDB(cafeId));
     }
-
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserDto.java
@@ -1,0 +1,20 @@
+package com.coffee.backend.domain.cafe.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CafeUserDto {
+    // userId, nickname, introduction
+    // TODO : email을 introduction으로 교체
+    private Long userId;
+    private String nickname;
+    private String email;
+
+    public CafeUserDto(Long userId, String nickname, String email) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserDto.java
@@ -8,11 +8,11 @@ import lombok.Setter;
 public class CafeUserDto {
     private Long userId;
     private String nickname;
-    private String email; // TODO : email을 introduction으로 교체
+    private String introduction;
 
-    public CafeUserDto(Long userId, String nickname, String email) {
+    public CafeUserDto(Long userId, String nickname, String introduction) {
         this.userId = userId;
         this.nickname = nickname;
-        this.email = email;
+        this.introduction = introduction;
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserDto.java
@@ -6,11 +6,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CafeUserDto {
-    // userId, nickname, introduction
-    // TODO : email을 introduction으로 교체
     private Long userId;
     private String nickname;
-    private String email;
+    private String email; // TODO : email을 introduction으로 교체
 
     public CafeUserDto(Long userId, String nickname, String email) {
         this.userId = userId;

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserProfileDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserProfileDto.java
@@ -1,0 +1,18 @@
+package com.coffee.backend.domain.cafe.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CafeUserProfileDto {
+    private final CafeUserDto cafeUserDto;
+    private String companyName;
+    private String positionName;
+
+    public CafeUserProfileDto(CafeUserDto cafeUserDto, String companyName, String positionName) {
+        this.cafeUserDto = cafeUserDto;
+        this.companyName = companyName;
+        this.positionName = positionName;
+    }
+}

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserProfileDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/dto/CafeUserProfileDto.java
@@ -6,12 +6,16 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CafeUserProfileDto {
-    private final CafeUserDto cafeUserDto;
+    private Long userId;
+    private String nickname;
+    private String introduction;
     private String companyName;
     private String positionName;
 
     public CafeUserProfileDto(CafeUserDto cafeUserDto, String companyName, String positionName) {
-        this.cafeUserDto = cafeUserDto;
+        this.userId = cafeUserDto.getUserId();
+        this.nickname = cafeUserDto.getNickname();
+        this.introduction = cafeUserDto.getIntroduction();
         this.companyName = companyName;
         this.positionName = positionName;
     }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafePublisher.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafePublisher.java
@@ -9,13 +9,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class CafePublisher {
     private final RedisTemplate<String, Object> redisTemplate;
+    private final CafeService cafeService;
 
     public void updateCafeChoice(CafeDto dto) {
         String loginId = dto.getLoginId();
         String cafeId = dto.getCafeId();
 
-        // redis update
-        redisTemplate.opsForValue().set(loginId, cafeId);
-        redisTemplate.convertAndSend("ch02", dto);
+        /*
+        redis update (Redis에 아래 형식으로 저장됨)
+            namespace = cafe
+            key = starbucks
+            value = set(user1, user2, user3)
+         */
+        String cafeChoiceKey = "cafe:" + cafeId;
+        redisTemplate.opsForSet().add(cafeChoiceKey, loginId); // 카페 ID에 해당하는 세트에 사용자 ID 추가
+
+        cafeService.getCafeByUserId(loginId); // 테스트!
+        redisTemplate.convertAndSend("ch02", dto); // ch02 채널로 dto 발행
     }
+
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafePublisher.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafePublisher.java
@@ -1,6 +1,8 @@
 package com.coffee.backend.domain.cafe.service;
 
 import com.coffee.backend.domain.cafe.dto.CafeDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -11,19 +13,23 @@ public class CafePublisher {
     private final RedisTemplate<String, Object> redisTemplate;
     private final CafeService cafeService;
 
-    public void updateCafeChoice(CafeDto dto) {
+    public void updateCafeChoice(CafeDto dto) throws JsonProcessingException {
         String loginId = dto.getLoginId();
         String cafeId = dto.getCafeId();
 
         /*
-        redis update (Redis에 아래 형식으로 저장됨)
+        Redis에 아래 형식으로 저장됨
             namespace = cafe
             key = starbucks
             value = set(user1, user2, user3)
          */
         String cafeChoiceKey = "cafe:" + cafeId;
         redisTemplate.opsForSet().add(cafeChoiceKey, loginId); // 카페 ID에 해당하는 세트에 사용자 ID 추가
-        redisTemplate.convertAndSend("ch02", dto); // ch02 채널로 dto 발행
-    }
 
+        // dto를 json으로 변환 (redisTemplate 직렬화 문제)
+        ObjectMapper objectMapper = new ObjectMapper();
+        String cafeDtoJson = objectMapper.writeValueAsString(dto);
+        redisTemplate.convertAndSend("ch02", cafeDtoJson); // ch02 채널로 dto 발행
+
+    }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafePublisher.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafePublisher.java
@@ -23,8 +23,6 @@ public class CafePublisher {
          */
         String cafeChoiceKey = "cafe:" + cafeId;
         redisTemplate.opsForSet().add(cafeChoiceKey, loginId); // 카페 ID에 해당하는 세트에 사용자 ID 추가
-
-        cafeService.getCafeByUserId(loginId); // 테스트!
         redisTemplate.convertAndSend("ch02", dto); // ch02 채널로 dto 발행
     }
 

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
@@ -1,0 +1,62 @@
+package com.coffee.backend.domain.cafe.service;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CafeService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    //TODO : CafeController.java 의 sendMatchRequest() 에서 호출됨 테스트용 데이터가 잘 조회되는지? 어떻게 조회되는지?
+    public String getCafeByUserId(String userId) {
+        // redis 에서 userId로 cafeId 조회
+        Object cafeId = redisTemplate.opsForValue().get(userId.toString());
+        System.out.println("userId= " + userId + " cafeId = " + cafeId); // userId = user1, cafeId = 1
+        return (String) cafeId;
+    }
+
+//    public void getUsersByCafeId(Long cafeId) {
+//        // TODO : 그 cafeId 를 가진 유저를 redis 에서 싹 조회하고
+//        Set<String> userSet = getUserListFromRedis(cafeId);
+//        // TODO : userSet에서 각 userId 꺼내서 그 userId로 DB에서 User entity, (Company entity, position entity) 를 조회
+//        아래 형식처럼 list에 담아 리턴
+//        /*
+//        리턴 형식 (companyName, positionName은 일단 NULL로 보낸다.)
+//            {
+//                "userList" : [
+//                {
+//                "userId" : Long
+//                "nickname" : String
+//                "introduction" : String
+//                "companyName" : String
+//                "positionName" : String
+//                },
+//                {
+//                    동일하게
+//                },
+//                ]
+//            }
+//         */
+//    }
+//
+
+    // redis 에서 cafeId로 조회해서 userList 리턴
+    public Set<Object> getUsersByCafeId(String cafeId) {
+        String cafeChoiceKey = "cafe:" + cafeId;
+        Set<Object> userSet = redisTemplate.opsForSet().members(cafeChoiceKey); // 카페 ID에 해당하는 세트의 모든 사용자 ID 조회
+        System.out.println("cafeId = " + cafeId + " userSet = " + userSet); // 출력
+        return userSet;
+    }
+
+//    //
+//    // userId로 User entity, Company entity, Position entity 조회
+//    public void getUserInfoFromDB(String userId) {
+//        User user = userRepository.findById(userId);
+//        Company company = companyRepository.findById(user.getCompanyId()); //아직 company entity 없음
+//    }
+}

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
@@ -21,54 +21,25 @@ public class CafeService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final UserService userService;
 
-    //TODO : CafeController.java 의 sendMatchRequest() 에서 호출됨 테스트용 데이터가 잘 조회되는지? 어떻게 조회되는지?
-    public String getCafeByUserId(String userId) {
-        // redis 에서 userId로 cafeId 조회
-        Object cafeId = redisTemplate.opsForValue().get(userId.toString());
-        System.out.println("userId= " + userId + " cafeId = " + cafeId); // userId = user1, cafeId = 1
-        return (String) cafeId;
-    }
+    public List<CafeUserProfileDto> getUserProfilesFromRedisAndDB(String cafeId) {
+        // cafeId 를 가진 유저를 redis 에서 싹 조회
+        Set<Object> userSet = getUserListFromRedis(cafeId);
 
-//    public void getUsersByCafeId(Long cafeId) {
-//        // TODO : 그 cafeId 를 가진 유저를 redis 에서 싹 조회하고
-//        Set<String> userSet = getUserListFromRedis(cafeId);
-//        // TODO : userSet에서 각 userId 꺼내서 그 userId로 DB에서 User entity, (Company entity, position entity) 를 조회
-//        아래 형식처럼 list에 담아 리턴
-//        /*
-//        리턴 형식 (companyName, positionName은 일단 NULL로 보낸다.)
-//            {
-//                "userList" : [
-//                {
-//                "userId" : Long
-//                "nickname" : String
-//                "introduction" : String
-//                "companyName" : String
-//                "positionName" : String
-//                },
-//                {
-//                    동일하게
-//                },
-//                ]
-//            }
-//         */
-//    }
-//
-
-    // redis 에서 cafeId로 조회해서 userList 리턴
-    public List<CafeUserProfileDto> getUsersByCafeId(String cafeId) {
-        String cafeChoiceKey = "cafe:" + cafeId;
-        Set<Object> userSet = redisTemplate.opsForSet().members(cafeChoiceKey);
-
-        return Optional.ofNullable(userSet).orElse(Collections.emptySet()).stream() //null일땐 빈 Set 반환
+        // 각 userId로 DB에서 User entity, (Company entity, position entity) 를 조회
+        return Optional.ofNullable(userSet).orElse(Collections.emptySet()).stream()
                 .filter(Objects::nonNull) // null 값 제거
                 .map(userId -> getUserInfoFromDB((String) userId))
-                .collect(Collectors.toList()); // 결과를 List로 수집
+                .collect(Collectors.toList());
     }
 
-    // userId로 User entity, Company entity, Position entity 조회
+    public Set<Object> getUserListFromRedis(String cafeId) {
+        String cafeChoiceKey = "cafe:" + cafeId;
+        return redisTemplate.opsForSet().members(cafeChoiceKey);
+    }
+
     public CafeUserProfileDto getUserInfoFromDB(String userId) {
         CafeUserDto cafeUserDto = userService.getCafeUserInfoByLoginId(userId); // userId로 User entity 조회
         // TODO : Company entity, Position entity 조회해서 cafeUserDto에 추가
-        return new CafeUserProfileDto(cafeUserDto, "임시값", "임시값");
+        return new CafeUserProfileDto(cafeUserDto, "임시 company", "임시 position");
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
@@ -1,9 +1,14 @@
 package com.coffee.backend.domain.cafe.service;
 
 import com.coffee.backend.domain.cafe.dto.CafeUserDto;
+import com.coffee.backend.domain.cafe.dto.CafeUserProfileDto;
 import com.coffee.backend.domain.user.service.UserService;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -50,19 +55,20 @@ public class CafeService {
 //
 
     // redis 에서 cafeId로 조회해서 userList 리턴
-    public Set<Object> getUsersByCafeId(String cafeId) {
+    public List<CafeUserProfileDto> getUsersByCafeId(String cafeId) {
         String cafeChoiceKey = "cafe:" + cafeId;
-        Set<Object> userSet = redisTemplate.opsForSet().members(cafeChoiceKey); // 카페 ID에 해당하는 세트의 모든 사용자 ID 조회
-//        System.out.println("cafeId = " + cafeId + " userSet = " + userSet); // 출력
-        for (Object userId : Objects.requireNonNull(userSet)) {
-            getUserInfoFromDB((String) userId);
-        }
-        return userSet;
+        Set<Object> userSet = redisTemplate.opsForSet().members(cafeChoiceKey);
+
+        return Optional.ofNullable(userSet).orElse(Collections.emptySet()).stream() //null일땐 빈 Set 반환
+                .filter(Objects::nonNull) // null 값 제거
+                .map(userId -> getUserInfoFromDB((String) userId))
+                .collect(Collectors.toList()); // 결과를 List로 수집
     }
 
     // userId로 User entity, Company entity, Position entity 조회
-    public void getUserInfoFromDB(String userId) {
+    public CafeUserProfileDto getUserInfoFromDB(String userId) {
         CafeUserDto cafeUserDto = userService.getCafeUserInfoByLoginId(userId); // userId로 User entity 조회
         // TODO : Company entity, Position entity 조회해서 cafeUserDto에 추가
+        return new CafeUserProfileDto(cafeUserDto, "임시값", "임시값");
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/cafe/service/CafeService.java
@@ -1,5 +1,8 @@
 package com.coffee.backend.domain.cafe.service;
 
+import com.coffee.backend.domain.cafe.dto.CafeUserDto;
+import com.coffee.backend.domain.user.service.UserService;
+import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class CafeService {
     private final RedisTemplate<String, Object> redisTemplate;
+    private final UserService userService;
 
     //TODO : CafeController.java 의 sendMatchRequest() 에서 호출됨 테스트용 데이터가 잘 조회되는지? 어떻게 조회되는지?
     public String getCafeByUserId(String userId) {
@@ -49,14 +53,16 @@ public class CafeService {
     public Set<Object> getUsersByCafeId(String cafeId) {
         String cafeChoiceKey = "cafe:" + cafeId;
         Set<Object> userSet = redisTemplate.opsForSet().members(cafeChoiceKey); // 카페 ID에 해당하는 세트의 모든 사용자 ID 조회
-        System.out.println("cafeId = " + cafeId + " userSet = " + userSet); // 출력
+//        System.out.println("cafeId = " + cafeId + " userSet = " + userSet); // 출력
+        for (Object userId : Objects.requireNonNull(userSet)) {
+            getUserInfoFromDB((String) userId);
+        }
         return userSet;
     }
 
-//    //
-//    // userId로 User entity, Company entity, Position entity 조회
-//    public void getUserInfoFromDB(String userId) {
-//        User user = userRepository.findById(userId);
-//        Company company = companyRepository.findById(user.getCompanyId()); //아직 company entity 없음
-//    }
+    // userId로 User entity, Company entity, Position entity 조회
+    public void getUserInfoFromDB(String userId) {
+        CafeUserDto cafeUserDto = userService.getCafeUserInfoByLoginId(userId); // userId로 User entity 조회
+        // TODO : Company entity, Position entity 조회해서 cafeUserDto에 추가
+    }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.coffee.backend.domain.user.service;
 
+import com.coffee.backend.domain.cafe.dto.CafeUserDto;
 import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.domain.user.repository.UserRepository;
 import com.coffee.backend.exception.CustomException;
@@ -22,5 +23,15 @@ public class UserService {
             log.info("id = {} 인 사용자가 존재하지 않습니다", userId);
             return new CustomException(ErrorCode.USER_NOT_FOUND);
         });
+    }
+
+    // 특정 카페에 접속한 사용자 list에 보일 User 데이터 조회
+    public CafeUserDto getCafeUserInfoByLoginId(String userId) {
+        return userRepository.findByLoginId(userId)
+                .map(user -> new CafeUserDto(user.getUserId(), user.getNickname(), user.getEmail()))
+                .orElseThrow(() -> {
+                    log.info("id = {} 인 사용자가 존재하지 않습니다", userId);
+                    return new CustomException(ErrorCode.USER_NOT_FOUND);
+                });
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
@@ -28,7 +28,8 @@ public class UserService {
     // 특정 카페에 접속한 사용자 list에 보일 User 데이터 조회
     public CafeUserDto getCafeUserInfoByLoginId(String userId) {
         return userRepository.findByLoginId(userId)
-                .map(user -> new CafeUserDto(user.getUserId(), user.getNickname(), user.getEmail()))
+                .map(user -> new CafeUserDto(user.getUserId(), user.getNickname(),
+                        user.getEmail())) // TODO : email을 introduction으로 교체
                 .orElseThrow(() -> {
                     log.info("id = {} 인 사용자가 존재하지 않습니다", userId);
                     return new CustomException(ErrorCode.USER_NOT_FOUND);

--- a/backend/src/main/java/com/coffee/backend/global/RedisConfig.java
+++ b/backend/src/main/java/com/coffee/backend/global/RedisConfig.java
@@ -10,7 +10,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -21,13 +20,19 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         final RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory());
+        template.setConnectionFactory(connectionFactory);
+
+        // 직렬화 설정
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
         return template;
     }
+
 
     // Redis의 channel로부터 메시지를 수신받아 해당 MessageListenerAdapter에게 dispatch
     @Bean


### PR DESCRIPTION
## #️⃣연관된 이슈

> #50 

## 📝작업 내용
> 카페 상세 페이지에 접속했을때, 다른 유저 list를 초기에 get 요청하는 로직입니다.
-  카페 선택을 통해 Redis에 값이 저장될 때의 형식을 변경했습니다. 
```
  namespace = cafe                    // cafe로 고정
  key = starbucks                     // 프론트에서 받은 cafeId
  value = set(user1, user2, user3)    // set에 저장된 사용자 목록
```
- GET 요청이 들어오면 Redis에서 해당 카페에 속한 모든 사용자 목록을 조회하고, User entity, Company entity, Position entity를 통해 각 사용자의 상세정보를 가져와 프론트로 보내도록 구현했습니다.

### 스크린샷 (선택)
1. 카페에 사용자가 있는 경우
![image](https://github.com/kookmin-sw/capstone-2024-17/assets/84231143/c487794b-1e12-4093-8e9d-8fb33dac2dc1)
2. 카페에 사용자가 없는 경우 (빈 list 반환)
![image](https://github.com/kookmin-sw/capstone-2024-17/assets/84231143/a317ebe3-8384-4517-b2c8-3dcb06a67245)