### PR TITLE
[feat] 카카오 로그인 및 회원가입 기능 구현 #14

### DIFF
--- a/backend/src/main/java/com/coffee/backend/BackendApplication.java
+++ b/backend/src/main/java/com/coffee/backend/BackendApplication.java
@@ -8,11 +8,9 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@EnableAsync
 @RestController
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableCaching

--- a/backend/src/main/java/com/coffee/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/controller/AuthController.java
@@ -2,9 +2,12 @@ package com.coffee.backend.domain.auth.controller;
 
 import com.coffee.backend.domain.auth.dto.AuthDto;
 import com.coffee.backend.domain.auth.dto.DeleteUserDto;
+import com.coffee.backend.domain.auth.dto.KakaoRequestDto;
+import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
 import com.coffee.backend.domain.auth.dto.SignInDto;
 import com.coffee.backend.domain.auth.dto.SignUpDto;
 import com.coffee.backend.domain.auth.service.AuthService;
+import com.coffee.backend.domain.auth.service.KakaoLoginService;
 import com.coffee.backend.domain.user.dto.UserDto;
 import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.exception.CustomException;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class AuthController {
     private final AuthService authService;
+    private final KakaoLoginService kakaoLoginService;
 
     @PostMapping("/signUp")
     public ResponseEntity<ApiResponse<UserDto>> signUp(
@@ -54,5 +58,12 @@ public class AuthController {
         } else {
             throw new CustomException(ErrorCode.DELETE_USER_FAILED);
         }
+    }
+
+    @PostMapping("/kakaoSignIn")
+    public ResponseEntity<ApiResponse<AuthDto>> kakaoLogin(@RequestBody KakaoRequestDto dto) {
+        KakaoUserInfoDto userInfoDto = kakaoLoginService.getUserInfo(dto.getAccessToken());
+        AuthDto authDto = kakaoLoginService.signIn(userInfoDto);
+        return ResponseEntity.ok(ApiResponse.success(authDto));
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/controller/AuthController.java
@@ -2,12 +2,9 @@ package com.coffee.backend.domain.auth.controller;
 
 import com.coffee.backend.domain.auth.dto.AuthDto;
 import com.coffee.backend.domain.auth.dto.DeleteUserDto;
-import com.coffee.backend.domain.auth.dto.KakaoRequestDto;
-import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
 import com.coffee.backend.domain.auth.dto.SignInDto;
 import com.coffee.backend.domain.auth.dto.SignUpDto;
 import com.coffee.backend.domain.auth.service.AuthService;
-import com.coffee.backend.domain.auth.service.KakaoLoginService;
 import com.coffee.backend.domain.user.dto.UserDto;
 import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.exception.CustomException;
@@ -29,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class AuthController {
     private final AuthService authService;
-    private final KakaoLoginService kakaoLoginService;
 
     @PostMapping("/signUp")
     public ResponseEntity<ApiResponse<UserDto>> signUp(
@@ -58,12 +54,5 @@ public class AuthController {
         } else {
             throw new CustomException(ErrorCode.DELETE_USER_FAILED);
         }
-    }
-
-    @PostMapping("/kakaoSignIn")
-    public ResponseEntity<ApiResponse<AuthDto>> kakaoLogin(@RequestBody KakaoRequestDto dto) {
-        KakaoUserInfoDto userInfoDto = kakaoLoginService.getUserInfo(dto.getAccessToken());
-        AuthDto authDto = kakaoLoginService.signIn(userInfoDto);
-        return ResponseEntity.ok(ApiResponse.success(authDto));
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/auth/controller/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/controller/AuthenticationPrincipalArgumentResolver.java
@@ -13,7 +13,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-@Component
+@Component("authenticationPrincipalArgumentResolver")
 @RequiredArgsConstructor
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
 

--- a/backend/src/main/java/com/coffee/backend/domain/auth/controller/KakaoLoginController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/controller/KakaoLoginController.java
@@ -1,27 +1,27 @@
-//package com.coffee.backend.domain.auth.controller;
-//
-//import com.coffee.backend.domain.auth.dto.AuthDto;
-//import com.coffee.backend.domain.auth.dto.KakaoRequestDto;
-//import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
-//import com.coffee.backend.domain.auth.service.KakaoLoginService;
-//import com.coffee.backend.utils.ApiResponse;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.PostMapping;
-//import org.springframework.web.bind.annotation.RequestBody;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RequiredArgsConstructor
-//@RestController
-//@RequestMapping("/auth/kakao")
-//public class KakaoLoginController {
-//    private final KakaoLoginService kakaoLoginService;
-//
-//    @PostMapping("/signIn")
-//    public ResponseEntity<ApiResponse<AuthDto>> kakaoLogin(@RequestBody KakaoRequestDto dto) {
-//        KakaoUserInfoDto userInfoDto = kakaoLoginService.getUserInfo(dto.getAccessToken());
-//        AuthDto authDto = kakaoLoginService.signIn(userInfoDto);
-//        return ResponseEntity.ok(ApiResponse.success(authDto));
-//    }
-//}
+package com.coffee.backend.domain.auth.controller;
+
+import com.coffee.backend.domain.auth.dto.AuthDto;
+import com.coffee.backend.domain.auth.dto.KakaoRequestDto;
+import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
+import com.coffee.backend.domain.auth.service.KakaoLoginService;
+import com.coffee.backend.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/kakao")
+@RequiredArgsConstructor
+public class KakaoLoginController {
+    private final KakaoLoginService kakaoLoginService;
+    
+    @PostMapping("/kakaoSignIn")
+    public ResponseEntity<ApiResponse<AuthDto>> kakaoLogin(@RequestBody KakaoRequestDto dto) {
+        KakaoUserInfoDto userInfoDto = kakaoLoginService.getUserInfo(dto.getAccessToken());
+        AuthDto authDto = kakaoLoginService.signIn(userInfoDto);
+        return ResponseEntity.ok(ApiResponse.success(authDto));
+    }
+}

--- a/backend/src/main/java/com/coffee/backend/domain/auth/controller/KakaoLoginController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/controller/KakaoLoginController.java
@@ -1,27 +1,27 @@
-package com.coffee.backend.domain.auth.controller;
-
-import com.coffee.backend.domain.auth.dto.AuthDto;
-import com.coffee.backend.domain.auth.dto.KakaoRequestDto;
-import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
-import com.coffee.backend.domain.auth.service.KakaoLoginService;
-import com.coffee.backend.utils.ApiResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RequiredArgsConstructor
-@RestController
-@RequestMapping("/auth/kakao")
-public class KakaoLoginController {
-    private final KakaoLoginService kakaoLoginService;
-
-    @PostMapping("/signIn")
-    public ResponseEntity<ApiResponse<AuthDto>> kakaoLogin(@RequestBody KakaoRequestDto dto) {
-        KakaoUserInfoDto userInfoDto = kakaoLoginService.getUserInfo(dto.getAccessToken());
-        AuthDto authDto = kakaoLoginService.signIn(userInfoDto);
-        return ResponseEntity.ok(ApiResponse.success(authDto));
-    }
-}
+//package com.coffee.backend.domain.auth.controller;
+//
+//import com.coffee.backend.domain.auth.dto.AuthDto;
+//import com.coffee.backend.domain.auth.dto.KakaoRequestDto;
+//import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
+//import com.coffee.backend.domain.auth.service.KakaoLoginService;
+//import com.coffee.backend.utils.ApiResponse;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@RequiredArgsConstructor
+//@RestController
+//@RequestMapping("/auth/kakao")
+//public class KakaoLoginController {
+//    private final KakaoLoginService kakaoLoginService;
+//
+//    @PostMapping("/signIn")
+//    public ResponseEntity<ApiResponse<AuthDto>> kakaoLogin(@RequestBody KakaoRequestDto dto) {
+//        KakaoUserInfoDto userInfoDto = kakaoLoginService.getUserInfo(dto.getAccessToken());
+//        AuthDto authDto = kakaoLoginService.signIn(userInfoDto);
+//        return ResponseEntity.ok(ApiResponse.success(authDto));
+//    }
+//}

--- a/backend/src/main/java/com/coffee/backend/domain/auth/controller/KakaoLoginController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/controller/KakaoLoginController.java
@@ -1,0 +1,27 @@
+package com.coffee.backend.domain.auth.controller;
+
+import com.coffee.backend.domain.auth.dto.AuthDto;
+import com.coffee.backend.domain.auth.dto.KakaoRequestDto;
+import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
+import com.coffee.backend.domain.auth.service.KakaoLoginService;
+import com.coffee.backend.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth/kakao")
+public class KakaoLoginController {
+    private final KakaoLoginService kakaoLoginService;
+
+    @PostMapping("/signIn")
+    public ResponseEntity<ApiResponse<AuthDto>> kakaoLogin(@RequestBody KakaoRequestDto dto) {
+        KakaoUserInfoDto userInfoDto = kakaoLoginService.getUserInfo(dto.getAccessToken());
+        AuthDto authDto = kakaoLoginService.signIn(userInfoDto);
+        return ResponseEntity.ok(ApiResponse.success(authDto));
+    }
+}

--- a/backend/src/main/java/com/coffee/backend/domain/auth/dto/KakaoRequestDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/dto/KakaoRequestDto.java
@@ -1,0 +1,10 @@
+package com.coffee.backend.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoRequestDto {
+    private String accessToken;
+}

--- a/backend/src/main/java/com/coffee/backend/domain/auth/dto/KakaoUserInfoDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/dto/KakaoUserInfoDto.java
@@ -6,5 +6,5 @@ import lombok.Setter;
 @Getter
 @Setter
 public class KakaoUserInfoDto {
-    private Long userId;
+    private Long kakaoId;
 }

--- a/backend/src/main/java/com/coffee/backend/domain/auth/dto/KakaoUserInfoDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/dto/KakaoUserInfoDto.java
@@ -1,0 +1,10 @@
+package com.coffee.backend.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserInfoDto {
+    private Long userId;
+}

--- a/backend/src/main/java/com/coffee/backend/domain/auth/service/KakaoLoginService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/service/KakaoLoginService.java
@@ -1,0 +1,66 @@
+package com.coffee.backend.domain.auth.service;
+
+import com.coffee.backend.domain.auth.dto.AuthDto;
+import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
+import com.coffee.backend.domain.user.entity.User;
+import com.coffee.backend.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@RequiredArgsConstructor
+@Service
+public class KakaoLoginService {
+    private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    @Value("${kakao.user_info_uri}")
+    private String userInfoURI;
+
+    public KakaoUserInfoDto getUserInfo(String accessToken) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(accessToken);
+
+            HttpEntity<String> request = new HttpEntity<>(headers);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    userInfoURI, HttpMethod.GET, request, String.class);
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                return objectMapper.readValue(response.getBody(), KakaoUserInfoDto.class);
+            } else {
+                throw new RuntimeException("Failed to retrieve user info from Kakao API");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("유저 정보를 받아올 수 없습니다.");
+        }
+    }
+
+    @Transactional
+    public AuthDto signIn(KakaoUserInfoDto dto) {
+        User user = userRepository.findById(dto.getUserId())
+                .orElseGet(User::new);
+
+        // DB에 정보 없으면 회원가입 처리
+        if (user.getUserId() == null) {
+            user.setUserId(dto.getUserId());
+            userRepository.save(user);
+        }
+
+        String token = jwtService.createAccessToken(user.getUserId());
+
+        return new AuthDto(user.getUserUUID(), token);
+    }
+}

--- a/backend/src/main/java/com/coffee/backend/domain/auth/service/KakaoLoginService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/service/KakaoLoginService.java
@@ -6,7 +6,6 @@ import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -48,16 +47,16 @@ public class KakaoLoginService {
 
     @Transactional
     public AuthDto signIn(KakaoUserInfoDto dto) {
-        User user = userRepository.findById(dto.getUserId())
+        User user = userRepository.findByKakaoId(dto.getKakaoId())
                 .orElseGet(User::new);
 
         // DB에 정보 없으면 회원가입 처리
-        if (user.getUserId() == null) {
-            user.setUserId(dto.getUserId());
+        if (user.getKakaoId() == null) {
+            user.setKakaoId(dto.getKakaoId());
             userRepository.save(user);
         }
 
-        String token = jwtService.createAccessToken(user.getUserId());
+        String token = jwtService.createAccessToken(user.getKakaoId());
 
         return new AuthDto(user.getUserUUID(), token);
     }

--- a/backend/src/main/java/com/coffee/backend/domain/company/entity/Company.java
+++ b/backend/src/main/java/com/coffee/backend/domain/company/entity/Company.java
@@ -1,6 +1,6 @@
 package com.coffee.backend.domain.company.entity;
 
-import com.coffee.backend.domain.Storage.entity.UploadFile;
+import com.coffee.backend.domain.storage.entity.UploadFile;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/backend/src/main/java/com/coffee/backend/domain/company/service/CompanyService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/company/service/CompanyService.java
@@ -1,6 +1,6 @@
 package com.coffee.backend.domain.company.service;
 
-import com.coffee.backend.domain.Storage.service.StorageService;
+import com.coffee.backend.domain.storage.service.StorageService;
 import com.coffee.backend.domain.company.dto.CompanyDto;
 import com.coffee.backend.domain.company.dto.EmailVerificationResponse;
 import com.coffee.backend.domain.company.entity.Company;

--- a/backend/src/main/java/com/coffee/backend/domain/storage/entity/UploadFile.java
+++ b/backend/src/main/java/com/coffee/backend/domain/storage/entity/UploadFile.java
@@ -1,4 +1,4 @@
-package com.coffee.backend.domain.Storage.entity;
+package com.coffee.backend.domain.storage.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/backend/src/main/java/com/coffee/backend/domain/storage/repository/UploadFileRepository.java
+++ b/backend/src/main/java/com/coffee/backend/domain/storage/repository/UploadFileRepository.java
@@ -1,6 +1,6 @@
-package com.coffee.backend.domain.Storage.Repository;
+package com.coffee.backend.domain.storage.repository;
 
-import com.coffee.backend.domain.Storage.entity.UploadFile;
+import com.coffee.backend.domain.storage.entity.UploadFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {

--- a/backend/src/main/java/com/coffee/backend/domain/storage/service/StorageService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/storage/service/StorageService.java
@@ -1,9 +1,9 @@
-package com.coffee.backend.domain.Storage.service;
+package com.coffee.backend.domain.storage.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.coffee.backend.domain.Storage.Repository.UploadFileRepository;
-import com.coffee.backend.domain.Storage.entity.UploadFile;
+import com.coffee.backend.domain.storage.repository.UploadFileRepository;
+import com.coffee.backend.domain.storage.entity.UploadFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/backend/src/main/java/com/coffee/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/entity/User.java
@@ -16,6 +16,7 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
+    private Long kakaoId;
     private String loginId;
     private String password;
     private String nickname;

--- a/backend/src/main/java/com/coffee/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     void deleteByUserUUID(String userUUID);
 
     Optional<User> findByEmail(final String email);
+
+    Optional<User> findByKakaoId(Long kakaoId);
 }

--- a/backend/src/main/java/com/coffee/backend/global/WebConfig.java
+++ b/backend/src/main/java/com/coffee/backend/global/WebConfig.java
@@ -1,6 +1,7 @@
 package com.coffee.backend.global;
 
 import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -11,7 +12,8 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver;
 
-    public WebConfig(HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver) {
+    public WebConfig(
+            @Qualifier("authenticationPrincipalArgumentResolver") HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver) {
         this.authenticationPrincipalArgumentResolver = authenticationPrincipalArgumentResolver;
     }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -34,3 +34,6 @@ spring:
     redis:
       host: redis
       port: 6379
+
+  kakao:
+    user_info_uri: https://kapi.kakao.com/v2/user/me

--- a/backend/src/test/java/com/coffee/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/coffee/backend/BackendApplicationTests.java
@@ -1,14 +1,14 @@
-//package com.coffee.backend;
-//
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//@SpringBootTest
-//class BackendApplicationTests {
-//
-//	@Test
-//	void contextLoads() {
-//	}
-//
-//}
+package com.coffee.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #14 

## 📝작업 내용

> 클라이언트로부터 accessToken을 전달받고, 카카오 유저 정보를 얻음

> 유저 정보가 DB에 존재할 시 로그인 JWT 토큰 발급, 존재하지 않을 시 회원가입 진행

## 참고 사항

**유저 DB 다시 짜야함!! 프/백 전체 상의 필요!!**