### PR TITLE
#133 alarm modal

### DIFF
--- a/frontend/lib/widgets/button/bottom_two_buttons.dart
+++ b/frontend/lib/widgets/button/bottom_two_buttons.dart
@@ -16,30 +16,14 @@ class BottomTwoButtonsSmall extends StatelessWidget {
   }
 }
 
-class BottomTwoButtonsMedium extends StatelessWidget {
-  final String first;
-  final String second;
-
-  const BottomTwoButtonsMedium({
-    super.key,
-    required this.first,
-    required this.second,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return BottomTwoButtons(width: 130, first: first, second: second);
-  }
-}
-
 class BottomTwoButtons extends StatelessWidget {
-  final double width;
+  final double? width;
   final String first;
   final String second;
 
   const BottomTwoButtons({
     super.key,
-    required this.width,
+    this.width = 130,
     required this.first,
     required this.second,
   });

--- a/frontend/lib/widgets/button/bottom_two_buttons.dart
+++ b/frontend/lib/widgets/button/bottom_two_buttons.dart
@@ -1,11 +1,45 @@
 import 'package:flutter/material.dart';
 
+class BottomTwoButtonsSmall extends StatelessWidget {
+  final String first;
+  final String second;
+
+  const BottomTwoButtonsSmall({
+    super.key,
+    required this.first,
+    required this.second,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomTwoButtons(width: 110, first: first, second: second);
+  }
+}
+
+class BottomTwoButtonsMedium extends StatelessWidget {
+  final String first;
+  final String second;
+
+  const BottomTwoButtonsMedium({
+    super.key,
+    required this.first,
+    required this.second,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomTwoButtons(width: 130, first: first, second: second);
+  }
+}
+
 class BottomTwoButtons extends StatelessWidget {
+  final double width;
   final String first;
   final String second;
 
   const BottomTwoButtons({
     super.key,
+    required this.width,
     required this.first,
     required this.second,
   });
@@ -16,7 +50,7 @@ class BottomTwoButtons extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
         SizedBox(
-          width: 130,
+          width: width,
           height: 50,
           child: ElevatedButton(
             onPressed: () {},
@@ -31,7 +65,7 @@ class BottomTwoButtons extends StatelessWidget {
           ),
         ),
         SizedBox(
-          width: 130,
+          width: width,
           height: 50,
           child: TextButton(
             onPressed: () {},

--- a/frontend/lib/widgets/notification_dialog.dart
+++ b/frontend/lib/widgets/notification_dialog.dart
@@ -42,6 +42,20 @@ class ReqDeniedNotification extends StatelessWidget {
   }
 }
 
+// 오프라인 전환 알림창
+class OfflineNotification extends StatelessWidget {
+  const OfflineNotification({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const NotificationDialogLong(
+      title: "카페를 지정해주세요!",
+      contents: "지정한 카페가 반경에서 벗어나 \n오프라인 상태로 바뀌었어요! 카페를 \n다시 지정해 주세요.",
+      button: "확인",
+    );
+  }
+}
+
 class NotificationDialog extends StatelessWidget {
   final String contents;
   final String firstButton;
@@ -91,6 +105,70 @@ class NotificationDialog extends StatelessWidget {
                         first: firstButton,
                         second: secondButton!,
                       ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class NotificationDialogLong extends StatelessWidget {
+  final String title;
+  final String contents;
+  final String button;
+
+  const NotificationDialogLong({
+    super.key,
+    required this.title,
+    required this.contents,
+    required this.button,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            top: -50,
+            left: 110,
+            child: Image.asset(
+              'assets/logo.png',
+              width: 80,
+            ),
+          ),
+          Container(
+            padding:
+                const EdgeInsets.only(top: 50, left: 25, right: 25, bottom: 20),
+            width: 300,
+            height: 300,
+            child: Column(
+              children: [
+                Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(
+                  height: 15,
+                ),
+                Text(
+                  contents,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 16),
+                ),
+                const Expanded(child: SizedBox()),
+                ModalButton(text: button, handlePressed: () {}),
               ],
             ),
           ),

--- a/frontend/lib/widgets/notification_dialog.dart
+++ b/frontend/lib/widgets/notification_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/widgets/button/bottom_two_buttons.dart';
+import 'package:frontend/widgets/button/modal_button.dart';
 
 // 커피챗 요청 도착 알림창
 class ArriveRequestNotification extends StatelessWidget {
@@ -24,7 +25,6 @@ class ReqAcceptedNotification extends StatelessWidget {
     return const NotificationDialog(
       contents: "OO 님이 커피챗 요청을 \n수락했어요!",
       firstButton: "확인",
-      secondButton: "닫기",
     );
   }
 }
@@ -38,7 +38,6 @@ class ReqDeniedNotification extends StatelessWidget {
     return const NotificationDialog(
       contents: "OO 님이 커피챗 요청을 \n거절했어요.. :(",
       firstButton: "확인",
-      secondButton: "닫기",
     );
   }
 }
@@ -46,13 +45,13 @@ class ReqDeniedNotification extends StatelessWidget {
 class NotificationDialog extends StatelessWidget {
   final String contents;
   final String firstButton;
-  final String secondButton;
+  final String? secondButton;
 
   const NotificationDialog({
     super.key,
     required this.contents,
     required this.firstButton,
-    required this.secondButton,
+    this.secondButton,
   });
 
   @override
@@ -86,10 +85,12 @@ class NotificationDialog extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: const TextStyle(fontSize: 20),
                 ),
-                BottomTwoButtonsSmall(
-                  first: firstButton,
-                  second: secondButton,
-                ),
+                (secondButton == null)
+                    ? ModalButton(text: firstButton, handlePressed: () {})
+                    : BottomTwoButtonsSmall(
+                        first: firstButton,
+                        second: secondButton!,
+                      ),
               ],
             ),
           ),

--- a/frontend/lib/widgets/notification_dialog.dart
+++ b/frontend/lib/widgets/notification_dialog.dart
@@ -15,6 +15,34 @@ class ArriveRequestNotification extends StatelessWidget {
   }
 }
 
+// 커피챗 요청 수락 알림창
+class ReqAcceptedNotification extends StatelessWidget {
+  const ReqAcceptedNotification({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const NotificationDialog(
+      contents: "OO 님이 커피챗 요청을 \n수락했어요!",
+      firstButton: "확인",
+      secondButton: "닫기",
+    );
+  }
+}
+
+// 커피챗 요청 거절 알림창
+class ReqDeniedNotification extends StatelessWidget {
+  const ReqDeniedNotification({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const NotificationDialog(
+      contents: "OO 님이 커피챗 요청을 \n거절했어요.. :(",
+      firstButton: "확인",
+      secondButton: "닫기",
+    );
+  }
+}
+
 class NotificationDialog extends StatelessWidget {
   final String contents;
   final String firstButton;

--- a/frontend/lib/widgets/notification_dialog.dart
+++ b/frontend/lib/widgets/notification_dialog.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/widgets/button/bottom_two_buttons.dart';
+
+class NotificationDialog extends StatelessWidget {
+  final String contents;
+  final String firstButton;
+  final String secondButton;
+
+  const NotificationDialog({
+    super.key,
+    required this.contents,
+    required this.firstButton,
+    required this.secondButton,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            top: -50,
+            left: 110,
+            child: Image.asset(
+              'assets/logo.png',
+              width: 80,
+            ),
+          ),
+          Container(
+            padding:
+                const EdgeInsets.only(top: 50, left: 20, right: 20, bottom: 20),
+            width: 300,
+            height: 210,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  contents,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 20),
+                ),
+                BottomTwoButtons(
+                  first: firstButton,
+                  second: secondButton,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/widgets/notification_dialog.dart
+++ b/frontend/lib/widgets/notification_dialog.dart
@@ -44,7 +44,7 @@ class NotificationDialog extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: const TextStyle(fontSize: 20),
                 ),
-                BottomTwoButtons(
+                BottomTwoButtonsSmall(
                   first: firstButton,
                   second: secondButton,
                 ),

--- a/frontend/lib/widgets/notification_dialog.dart
+++ b/frontend/lib/widgets/notification_dialog.dart
@@ -1,6 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/widgets/button/bottom_two_buttons.dart';
 
+// 커피챗 요청 도착 알림창
+class ArriveRequestNotification extends StatelessWidget {
+  const ArriveRequestNotification({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const NotificationDialog(
+      contents: "새로운 커피챗 요청이 \n도착했어요!",
+      firstButton: "보기",
+      secondButton: "닫기",
+    );
+  }
+}
+
 class NotificationDialog extends StatelessWidget {
   final String contents;
   final String firstButton;

--- a/frontend/lib/widgets/user_item.dart
+++ b/frontend/lib/widgets/user_item.dart
@@ -163,7 +163,7 @@ class ReceivedReqDialog extends StatelessWidget {
             ),
             const ColorTextContainer(text: "# 당신의 업무가 궁금해요."),
             const Expanded(child: SizedBox()),
-            const BottomTwoButtons(
+            const BottomTwoButtonsMedium(
               first: "수락",
               second: "거절",
             ),

--- a/frontend/lib/widgets/user_item.dart
+++ b/frontend/lib/widgets/user_item.dart
@@ -163,7 +163,7 @@ class ReceivedReqDialog extends StatelessWidget {
             ),
             const ColorTextContainer(text: "# 당신의 업무가 궁금해요."),
             const Expanded(child: SizedBox()),
-            const BottomTwoButtonsMedium(
+            const BottomTwoButtons(
               first: "수락",
               second: "거절",
             ),


### PR DESCRIPTION
## #️⃣연관된 이슈

> #133 알림 모달창 UI

## 📝작업 내용

> 푸시알림 모달창 UI 작업

### 스크린샷 (선택)
<img width="200" alt="스크린샷 2024-04-30 오후 7 26 33" src="https://github.com/kookmin-sw/capstone-2024-17/assets/96081455/e4439804-337a-47cd-8c75-ae0c8c89d348">
<img width="200" alt="스크린샷 2024-04-30 오후 7 22 05" src="https://github.com/kookmin-sw/capstone-2024-17/assets/96081455/2582fc36-6fd9-43f7-b34d-a35154a8ff01">
<img width="200" alt="스크린샷 2024-04-30 오후 7 28 59" src="https://github.com/kookmin-sw/capstone-2024-17/assets/96081455/4fec34d7-4b13-4bc6-8815-94746dd392fe">
<img width="200" alt="스크린샷 2024-04-30 오후 7 54 34" src="https://github.com/kookmin-sw/capstone-2024-17/assets/96081455/391ceb1d-d23b-4790-b191-e0004b49bcc4">


## 💬리뷰 요구사항(선택)

> bottom_two_buttons.dart 파일에서 버튼을 크기에 따라 두 위젯으로 나누고, 공통되는 부분을 마찬가지로 하나의 위젯으로 만들었는데 이 때문에 파라미터를 두 번 넘겨줘야 하는 문제점이 있습니다.. 더 좋은 방법이 있을까요?
