### PR TITLE
[FEATURE] 직무, 자기소개 수정 api #168 # 169

### DIFF
--- a/backend/src/main/java/com/coffee/backend/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.coffee.backend.domain.auth.dto.SignUpDto;
 import com.coffee.backend.domain.redis.exception.RedisOperationException;
 import com.coffee.backend.domain.redis.service.TokenStorageService;
 import com.coffee.backend.domain.user.dto.UserDto;
+import com.coffee.backend.domain.user.entity.Position;
 import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.domain.user.repository.UserRepository;
 import com.coffee.backend.exception.CustomException;
@@ -42,6 +43,7 @@ public class AuthService {
         User user = mapper.map(dto, User.class);
         user.setPassword(passwordEncoder.encode(dto.getPassword()));
         user.setUserUUID(UUID.randomUUID().toString());
+        user.setPosition(Position.P00);
 
         User savedUser = userRepository.save(user);
         return customMapper.toUserDto(savedUser);

--- a/backend/src/main/java/com/coffee/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/controller/UserController.java
@@ -4,12 +4,16 @@ import com.coffee.backend.domain.auth.controller.AuthenticationPrincipal;
 import com.coffee.backend.domain.user.dto.IntroductionUpdateRequest;
 import com.coffee.backend.domain.user.dto.PositionUpdateRequest;
 import com.coffee.backend.domain.user.dto.UserDto;
+import com.coffee.backend.domain.user.entity.Position;
 import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.domain.user.service.UserService;
 import com.coffee.backend.utils.ApiResponse;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,16 +29,18 @@ public class UserController {
     @PostMapping("/position/update")
     public ResponseEntity<ApiResponse<UserDto>> position(@AuthenticationPrincipal User user,
                                                          @RequestBody PositionUpdateRequest dto) {
-
         return ResponseEntity.ok(ApiResponse.success(userService.updateUserPosition(user, dto.getPosition())));
     }
 
     @PostMapping("/introduction/update")
     public ResponseEntity<ApiResponse<UserDto>> position(@AuthenticationPrincipal User user,
                                                          @RequestBody IntroductionUpdateRequest dto) {
-
         return ResponseEntity.ok(ApiResponse.success(userService.updateUserIntroduction(user, dto.getIntroduction())));
     }
 
-
+    @GetMapping("/position/list")
+    public ResponseEntity<ApiResponse<List<String>>> positionList() {
+        return ResponseEntity.ok(
+                ApiResponse.success(Arrays.stream(Position.values()).map(position -> position.getName()).toList()));
+    }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.coffee.backend.domain.user.controller;
+
+import com.coffee.backend.domain.auth.controller.AuthenticationPrincipal;
+import com.coffee.backend.domain.user.dto.IntroductionUpdateRequest;
+import com.coffee.backend.domain.user.dto.PositionUpdateRequest;
+import com.coffee.backend.domain.user.dto.UserDto;
+import com.coffee.backend.domain.user.entity.User;
+import com.coffee.backend.domain.user.service.UserService;
+import com.coffee.backend.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/position/update")
+    public ResponseEntity<ApiResponse<UserDto>> position(@AuthenticationPrincipal User user,
+                                                         @RequestBody PositionUpdateRequest dto) {
+
+        return ResponseEntity.ok(ApiResponse.success(userService.updateUserPosition(user, dto.getPosition())));
+    }
+
+    @PostMapping("/introduction/update")
+    public ResponseEntity<ApiResponse<UserDto>> position(@AuthenticationPrincipal User user,
+                                                         @RequestBody IntroductionUpdateRequest dto) {
+
+        return ResponseEntity.ok(ApiResponse.success(userService.updateUserIntroduction(user, dto.getIntroduction())));
+    }
+
+
+}

--- a/backend/src/main/java/com/coffee/backend/domain/user/dto/IntroductionUpdateRequest.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/dto/IntroductionUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.coffee.backend.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class IntroductionUpdateRequest {
+    private String introduction;
+}

--- a/backend/src/main/java/com/coffee/backend/domain/user/dto/PositionUpdateRequest.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/dto/PositionUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.coffee.backend.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PositionUpdateRequest {
+    private String position;
+}

--- a/backend/src/main/java/com/coffee/backend/domain/user/dto/UserDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/dto/UserDto.java
@@ -17,6 +17,7 @@ public class UserDto {
     private String loginId;
     private Long kakaoId;
     private CompanyDto company;
+    private String position;
     private String nickname;
     private String email;
     private String phone;

--- a/backend/src/main/java/com/coffee/backend/domain/user/entity/Position.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/entity/Position.java
@@ -1,0 +1,56 @@
+package com.coffee.backend.domain.user.entity;
+
+import com.coffee.backend.exception.CustomException;
+import com.coffee.backend.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+@Getter
+public enum Position {
+    P00("선택안함"),
+    P01("서버/백엔드"),
+    P02("프론트엔드"),
+    P03("웹 풀스택"),
+    P04("안드로이드"),
+    P05("ios"),
+    P06("머신러닝"),
+    P07("인공지능(AI)"),
+    P08("데이터 엔지니어링"),
+    P09("DBA"),
+    P10("모바일 게임"),
+    P11("게임 클라이언트"),
+    P12("게임 서버"),
+    P13("시스템 소프트웨어"),
+    P14("시스템/네트워크"),
+    P15("데브옵스"),
+    P16("인터넷 보안"),
+    P17("임베디드 소프트웨어"),
+    P18("로보틱스 미들웨어"),
+    P19("QA"),
+    P20("사물인터넷(IoT)"),
+    P21("응용 프로그램"),
+    P22("블록체인"),
+    P23("개발PM"),
+    P24("웹 퍼블리싱"),
+    P25("크로스 플랫폼"),
+    P26("VR/AR/3D"),
+    P27("ERP"),
+    P28("그래픽스");
+
+    private final String name;
+
+    @JsonCreator // value 이름으로 Position 생성 (ex. "선택안함" -> Position.P00)
+    public static Position of(final String param) {
+        return Arrays.stream(values()).filter(position -> position.name.equals(param))
+                .findFirst()
+                .orElseThrow(() -> {
+                    log.info("Invalid position: {}", param);
+                    return new CustomException(ErrorCode.ILLEGAL_ARGUMENT_POSITION);
+                });
+    }
+}

--- a/backend/src/main/java/com/coffee/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/entity/User.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Table(name = "user")
@@ -24,11 +25,11 @@ public class User {
     private Long kakaoId;
     private String loginId;
     private String password;
-
     @ManyToOne
     @JoinColumn(name = "company_id")
     private Company company;
     @Enumerated(EnumType.ORDINAL)
+    @ColumnDefault(value = "0")
     private Position position;
     private String nickname;
     private String email;

--- a/backend/src/main/java/com/coffee/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package com.coffee.backend.domain.user.entity;
 
 import com.coffee.backend.domain.company.entity.Company;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,11 +28,8 @@ public class User {
     @ManyToOne
     @JoinColumn(name = "company_id")
     private Company company;
-
-//    @ManyToOne
-//    @JoinColumn(name = "position_id")
-//    private Position position;
-
+    @Enumerated(EnumType.ORDINAL)
+    private Position position;
     private String nickname;
     private String email;
     private String phone;

--- a/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
@@ -2,10 +2,13 @@ package com.coffee.backend.domain.user.service;
 
 import com.coffee.backend.domain.cafe.dto.CafeUserDto;
 import com.coffee.backend.domain.company.entity.Company;
+import com.coffee.backend.domain.user.dto.UserDto;
+import com.coffee.backend.domain.user.entity.Position;
 import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.domain.user.repository.UserRepository;
 import com.coffee.backend.exception.CustomException;
 import com.coffee.backend.exception.ErrorCode;
+import com.coffee.backend.utils.CustomMapper;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserService {
     private final UserRepository userRepository;
+    private final CustomMapper customMapper;
 
     public User getByUserId(Long userId) {
         Optional<User> user = userRepository.findById(userId);
@@ -56,5 +60,15 @@ public class UserService {
     public void setUserCompany(User user, Company company) {
         user.setCompany(company);
         userRepository.save(user);
+    }
+
+    public UserDto updateUserPosition(User user, String position) {
+        user.setPosition(Position.of(position));
+        return customMapper.toUserDto(userRepository.save(user));
+    }
+
+    public UserDto updateUserIntroduction(User user, String introduction) {
+        user.setIntroduction(introduction);
+        return customMapper.toUserDto(userRepository.save(user));
     }
 }

--- a/backend/src/main/java/com/coffee/backend/exception/ErrorCode.java
+++ b/backend/src/main/java/com/coffee/backend/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     LOGIN_ID_DUPLICATED(HttpStatus.CONFLICT, "1409", "로그인 ID가 중복됩니다"),
     DELETE_USER_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "1500", "사용자 탈퇴 처리 중 오류가 발생했습니다."),
 
+    ILLEGAL_ARGUMENT_POSITION(HttpStatus.NOT_FOUND, "2404", "잘못 된 직무를 입력했습니다."),
+
     FCM_ACCESS_TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5500", "FCM 액세스 토큰을 가져오는 중 오류가 발생했습니다."),
     FCM_MESSAGE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "5400", "FCM 메시지 포맷이 잘못되었습니다."),
     FCM_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5501", "FCM 메시지 전송 중 오류가 발생했습니다."),

--- a/backend/src/main/java/com/coffee/backend/utils/CustomMapper.java
+++ b/backend/src/main/java/com/coffee/backend/utils/CustomMapper.java
@@ -18,6 +18,9 @@ public class CustomMapper {
     public UserDto toUserDto(User user) {
         return mapper.typeMap(User.class, UserDto.class)
                 .setPostConverter(context -> {
+                    context.getDestination()
+                            .setPosition(context.getSource().getPosition().getName());
+
                     Company company = context.getSource().getCompany();
                     if (company != null) {
                         var dto = CompanyDto.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #168 , resolve #169, resolve #114 

## 📝작업 내용

> 직무 enum 클래스로 작업함

### 스크린샷 (선택)

> #### 직무 update
> ![Screenshot from 2024-05-05 17-40-24](https://github.com/kookmin-sw/capstone-2024-17/assets/84117653/8d0ddcee-6479-4d56-a159-79ca60bba4c1)

> #### 직무 리스트
> ![Screenshot from 2024-05-05 18-01-03](https://github.com/kookmin-sw/capstone-2024-17/assets/84117653/4b769f6a-4827-4c14-bb48-ec8149ea8afc)


## 💬리뷰 요구사항(선택)

> 직무, 자기소개 변경 api는 성공 시 응답으로 변경된 UserInfo 넘겨줌 -> 이걸로 유저정보 전역변수 업데이트하기

> User table에서 position 필드는 tinyint 타입으로,` 0, 1, 2, ...` 같은 정수가 저장됨