### PR TITLE
[fix] 매칭 정보 커피온도 null 수정 #247

### DIFF
--- a/backend/src/main/java/com/coffee/backend/domain/user/dto/ReceiverInfoDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/dto/ReceiverInfoDto.java
@@ -11,5 +11,5 @@ public class ReceiverInfoDto {
     private Company company;
     private String position;
     private String introduction;
-    private String rating;
+    private double coffeeBean;
 }

--- a/backend/src/main/java/com/coffee/backend/domain/user/dto/SenderInfoDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/dto/SenderInfoDto.java
@@ -12,5 +12,5 @@ public class SenderInfoDto {
     private Company company;
     private String position;
     private String introduction;
-    private String rating;
+    private double coffeeBean;
 }

--- a/backend/src/main/java/com/coffee/backend/domain/user/dto/UserDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/dto/UserDto.java
@@ -24,5 +24,5 @@ public class UserDto {
     private String userUUID;
     private String introduction;
     private String deviceToken;
-    private Double coffeeBean;
+    private double coffeeBean;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #247 

## 📝작업 내용

> coffeeBean Double 타입으로 되어있는 것 double 타입으로 수정
> 매칭 정보 불러올 때, 커피온도 null로 오는 것 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
