### PR TITLE
#258 fix profile

### DIFF
--- a/frontend/lib/screen/chat_screen.dart
+++ b/frontend/lib/screen/chat_screen.dart
@@ -15,13 +15,13 @@ import 'package:stomp_dart_client/stomp.dart';
 class ChatScreen extends StatefulWidget {
   final int chatroomId;
   final String nickname;
-  final Image logoImage;
+  final String logoUrl;
 
   const ChatScreen({
     super.key,
     required this.chatroomId,
     required this.nickname,
-    required this.logoImage,
+    required this.logoUrl,
   });
 
   @override
@@ -74,7 +74,7 @@ class _ChatScreenState extends State<ChatScreen> {
     });
     return Scaffold(
       appBar: ChatroomAppBar(
-        logoImage: widget.logoImage,
+        logoUrl: widget.logoUrl,
         nickname: widget.nickname,
       ),
       body: Container(

--- a/frontend/lib/screen/chatroom_list_screen.dart
+++ b/frontend/lib/screen/chatroom_list_screen.dart
@@ -65,7 +65,7 @@ class _ChatroomListScreenState extends State<ChatroomListScreen> {
         nickname: nickname,
         recentMessage: recentMessage,
         count: 0, // 일단 0으로 설정
-        company: chatroom['userInfo']['company']['name'],
+        logoUrl: chatroom['userInfo']['company']['logoUrl'],
       );
     }).toList();
   }

--- a/frontend/lib/screen/chatroom_list_screen.dart
+++ b/frontend/lib/screen/chatroom_list_screen.dart
@@ -63,7 +63,6 @@ class _ChatroomListScreenState extends State<ChatroomListScreen> {
       return ChatroomItem(
         id: id,
         nickname: nickname,
-        logoImage: null, // 일단 null로 설정
         recentMessage: recentMessage,
         count: 0, // 일단 0으로 설정
         company: chatroom['userInfo']['company']['name'],

--- a/frontend/lib/screen/chatroom_list_screen.dart
+++ b/frontend/lib/screen/chatroom_list_screen.dart
@@ -66,6 +66,7 @@ class _ChatroomListScreenState extends State<ChatroomListScreen> {
         logoImage: null, // 일단 null로 설정
         recentMessage: recentMessage,
         count: 0, // 일단 0으로 설정
+        company: chatroom['userInfo']['company']['name'],
       );
     }).toList();
   }

--- a/frontend/lib/screen/user_screen.dart
+++ b/frontend/lib/screen/user_screen.dart
@@ -86,10 +86,10 @@ class _UserScreenState extends State<UserScreen> {
                             child: Row(
                               children: <Widget>[
                                 (logoInfo == '')
-                                    ? const ProfileImg(
+                                    ? const ProfileImgMedium(
                                         isLocal: true,
                                         logoUrl: "assets/coffee_bean.png")
-                                    : ProfileImg(
+                                    : ProfileImgMedium(
                                         isLocal: false,
                                         logoUrl: logoInfo,
                                       ),

--- a/frontend/lib/screen/user_screen.dart
+++ b/frontend/lib/screen/user_screen.dart
@@ -6,6 +6,7 @@ import 'package:frontend/service/api_service.dart';
 import 'package:frontend/widgets/alert_dialog_widget.dart';
 import 'package:frontend/widgets/big_thermometer.dart';
 import 'package:frontend/widgets/button/bottom_text_button.dart';
+import 'package:frontend/widgets/profile_img.dart';
 import 'package:frontend/widgets/top_appbar.dart';
 
 class UserScreen extends StatefulWidget {
@@ -20,8 +21,7 @@ class _UserScreenState extends State<UserScreen> {
   String? token;
   bool isLogined = false;
   String nickname = '';
-  String logoInfo =
-      'https://capstone2024-17-coffeechat.s3.ap-northeast-2.amazonaws.com/coffeechat-logo.png';
+  String logoInfo = '';
   String companyName = '미인증';
   String position = '선택안함';
   int temperature = 0;
@@ -85,8 +85,11 @@ class _UserScreenState extends State<UserScreen> {
                             margin: const EdgeInsets.symmetric(vertical: 10),
                             child: Row(
                               children: <Widget>[
-                                Image.network(logoInfo,
-                                    width: 100, height: 100),
+                                (logoInfo == '')
+                                    ? const ProfileImg(
+                                        logo: "assets/coffee_bean.png")
+                                    : Image.network(logoInfo,
+                                        width: 100, height: 100),
                                 const SizedBox(
                                   width: 30,
                                 ),

--- a/frontend/lib/screen/user_screen.dart
+++ b/frontend/lib/screen/user_screen.dart
@@ -87,9 +87,12 @@ class _UserScreenState extends State<UserScreen> {
                               children: <Widget>[
                                 (logoInfo == '')
                                     ? const ProfileImg(
-                                        logo: "assets/coffee_bean.png")
-                                    : Image.network(logoInfo,
-                                        width: 100, height: 100),
+                                        isLocal: true,
+                                        logoUrl: "assets/coffee_bean.png")
+                                    : ProfileImg(
+                                        isLocal: false,
+                                        logoUrl: logoInfo,
+                                      ),
                                 const SizedBox(
                                   width: 30,
                                 ),

--- a/frontend/lib/widgets/chatroom_item.dart
+++ b/frontend/lib/widgets/chatroom_item.dart
@@ -7,6 +7,7 @@ class ChatroomItem extends StatelessWidget {
   final Image? logoImage;
   final String? recentMessage;
   final int count;
+  final String company;
 
   const ChatroomItem({
     super.key,
@@ -15,6 +16,7 @@ class ChatroomItem extends StatelessWidget {
     required this.logoImage,
     required this.recentMessage,
     required this.count,
+    required this.company,
   });
 
   @override
@@ -29,7 +31,8 @@ class ChatroomItem extends StatelessWidget {
                   builder: (context) => ChatScreen(
                         chatroomId: id,
                         nickname: nickname,
-                        logoImage: logoImage ?? Image.asset('assets/logo.png'),
+                        logoImage: logoImage ??
+                            Image.asset('assets/$company-logo.png'),
                       )));
         });
       },
@@ -43,7 +46,8 @@ class ChatroomItem extends StatelessWidget {
                 child: CircleAvatar(
                   radius: 40,
                   backgroundImage:
-                      (logoImage ?? Image.asset('assets/logo.png')).image,
+                      (logoImage ?? Image.asset('assets/$company-logo.png'))
+                          .image,
                 ),
               ),
               Expanded(

--- a/frontend/lib/widgets/chatroom_item.dart
+++ b/frontend/lib/widgets/chatroom_item.dart
@@ -4,7 +4,6 @@ import 'package:frontend/screen/chat_screen.dart';
 class ChatroomItem extends StatelessWidget {
   final int id;
   final String nickname;
-  final Image? logoImage;
   final String? recentMessage;
   final int count;
   final String company;
@@ -13,7 +12,6 @@ class ChatroomItem extends StatelessWidget {
     super.key,
     required this.id,
     required this.nickname,
-    required this.logoImage,
     required this.recentMessage,
     required this.count,
     required this.company,
@@ -31,8 +29,7 @@ class ChatroomItem extends StatelessWidget {
                   builder: (context) => ChatScreen(
                         chatroomId: id,
                         nickname: nickname,
-                        logoImage: logoImage ??
-                            Image.asset('assets/$company-logo.png'),
+                        logoImage: Image.asset('assets/$company-logo.png'),
                       )));
         });
       },
@@ -46,8 +43,7 @@ class ChatroomItem extends StatelessWidget {
                 child: CircleAvatar(
                   radius: 40,
                   backgroundImage:
-                      (logoImage ?? Image.asset('assets/$company-logo.png'))
-                          .image,
+                      (Image.asset('assets/$company-logo.png')).image,
                 ),
               ),
               Expanded(

--- a/frontend/lib/widgets/chatroom_item.dart
+++ b/frontend/lib/widgets/chatroom_item.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/screen/chat_screen.dart';
+import 'package:frontend/widgets/profile_img.dart';
 
 class ChatroomItem extends StatelessWidget {
   final int id;
   final String nickname;
   final String? recentMessage;
   final int count;
-  final String company;
+  final String logoUrl;
 
   const ChatroomItem({
     super.key,
@@ -14,7 +15,7 @@ class ChatroomItem extends StatelessWidget {
     required this.nickname,
     required this.recentMessage,
     required this.count,
-    required this.company,
+    required this.logoUrl,
   });
 
   @override
@@ -22,16 +23,21 @@ class ChatroomItem extends StatelessWidget {
     return GestureDetector(
       onTap: () {
         // print('탭됨: $id');
-        Future.delayed(Duration.zero, () {
-          Navigator.push(
+        Future.delayed(
+          Duration.zero,
+          () {
+            Navigator.push(
               context,
               MaterialPageRoute(
-                  builder: (context) => ChatScreen(
-                        chatroomId: id,
-                        nickname: nickname,
-                        logoImage: Image.asset('assets/$company-logo.png'),
-                      )));
-        });
+                builder: (context) => ChatScreen(
+                  chatroomId: id,
+                  nickname: nickname,
+                  logoUrl: logoUrl,
+                ),
+              ),
+            );
+          },
+        );
       },
       child: Card(
         child: Container(
@@ -40,11 +46,15 @@ class ChatroomItem extends StatelessWidget {
             children: [
               Container(
                 padding: const EdgeInsets.all(10),
-                child: CircleAvatar(
-                  radius: 40,
-                  backgroundImage:
-                      (Image.asset('assets/$company-logo.png')).image,
-                ),
+                child: (logoUrl == '')
+                    ? const ProfileImgSmall(
+                        isLocal: true,
+                        logoUrl: "assets/coffee_bean.png",
+                      )
+                    : ProfileImgSmall(
+                        isLocal: false,
+                        logoUrl: logoUrl,
+                      ),
               ),
               Expanded(
                 child: Column(

--- a/frontend/lib/widgets/choose_purpose.dart
+++ b/frontend/lib/widgets/choose_purpose.dart
@@ -18,9 +18,9 @@ class ChoosePurpose extends StatelessWidget {
   final int userId; // receiverId 추가
 
   const ChoosePurpose({
-    Key? key,
+    super.key,
     required this.userId, // 생성자에 receiverId 추가
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -101,7 +101,6 @@ class ChoosePurpose extends StatelessWidget {
                             ['nickname'] ??
                         "nickname";
                     var company = inforesponse['data']['receiverInfo']
-
                             ['company']['name'] ??
                         "company";
                     var position = inforesponse['data']['receiverInfo']
@@ -110,8 +109,9 @@ class ChoosePurpose extends StatelessWidget {
                     var introduction = inforesponse['data']['receiverInfo']
                             ['introduction'] ??
                         "introduction";
-                    double rating =
-                        inforesponse['data']['receiverInfo']['rating'] ?? 0.0;
+                    double rating = inforesponse['data']['receiverInfo']
+                            ['coffeeBean'] ??
+                        0.0;
 
                     int requestType =
                         int.parse(inforesponse['data']['requestTypeId'] ?? '0');
@@ -154,11 +154,11 @@ class PurposeButton extends StatefulWidget {
   final Function(int) onIndexChanged; // 새로운 함수 추가
 
   const PurposeButton({
-    Key? key,
+    super.key,
     required this.purpose,
     required this.selectedindex,
     required this.onIndexChanged, // 생성자에 함수 추가
-  }) : super(key: key);
+  });
 
   @override
   State<PurposeButton> createState() => _PurposeButtonState();

--- a/frontend/lib/widgets/profile_img.dart
+++ b/frontend/lib/widgets/profile_img.dart
@@ -3,23 +3,25 @@ import 'package:flutter/material.dart';
 class ProfileImg extends StatelessWidget {
   final bool isLocal;
   final String logoUrl;
+  final double size;
 
   const ProfileImg({
     super.key,
     required this.isLocal,
     required this.logoUrl,
+    required this.size,
   });
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 100,
+      width: size,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(color: Colors.grey),
       ),
       child: CircleAvatar(
-        radius: 50,
+        radius: size / 2,
         backgroundColor: Colors.white,
         child: ClipOval(
           child: (isLocal)
@@ -34,5 +36,53 @@ class ProfileImg extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class ProfileImgMedium extends StatelessWidget {
+  final bool isLocal;
+  final String logoUrl;
+
+  const ProfileImgMedium({
+    super.key,
+    required this.isLocal,
+    required this.logoUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ProfileImg(isLocal: isLocal, logoUrl: logoUrl, size: 100);
+  }
+}
+
+class ProfileImgSmall extends StatelessWidget {
+  final bool isLocal;
+  final String logoUrl;
+
+  const ProfileImgSmall({
+    super.key,
+    required this.isLocal,
+    required this.logoUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ProfileImg(isLocal: isLocal, logoUrl: logoUrl, size: 80);
+  }
+}
+
+class ProfileImgXSmall extends StatelessWidget {
+  final bool isLocal;
+  final String logoUrl;
+
+  const ProfileImgXSmall({
+    super.key,
+    required this.isLocal,
+    required this.logoUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ProfileImg(isLocal: isLocal, logoUrl: logoUrl, size: 50);
   }
 }

--- a/frontend/lib/widgets/profile_img.dart
+++ b/frontend/lib/widgets/profile_img.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 
 class ProfileImg extends StatelessWidget {
-  final String logo;
+  final bool isLocal;
+  final String logoUrl;
 
   const ProfileImg({
     super.key,
-    required this.logo,
+    required this.isLocal,
+    required this.logoUrl,
   });
 
   @override
@@ -20,10 +22,15 @@ class ProfileImg extends StatelessWidget {
         radius: 50,
         backgroundColor: Colors.white,
         child: ClipOval(
-          child: Image.asset(
-            logo,
-            fit: BoxFit.cover, // 이미지가 원 안에 꽉 차도록 합니다
-          ),
+          child: (isLocal)
+              ? Image.asset(
+                  logoUrl,
+                  fit: BoxFit.cover, // 이미지가 원 안에 꽉 차도록 합니다
+                )
+              : Image.network(
+                  logoUrl,
+                  fit: BoxFit.cover,
+                ),
         ),
       ),
     );

--- a/frontend/lib/widgets/profile_img.dart
+++ b/frontend/lib/widgets/profile_img.dart
@@ -19,7 +19,12 @@ class ProfileImg extends StatelessWidget {
       child: CircleAvatar(
         radius: 50,
         backgroundColor: Colors.white,
-        backgroundImage: AssetImage(logo),
+        child: ClipOval(
+          child: Image.asset(
+            logo,
+            fit: BoxFit.cover, // 이미지가 원 안에 꽉 차도록 합니다
+          ),
+        ),
       ),
     );
   }

--- a/frontend/lib/widgets/top_appbar.dart
+++ b/frontend/lib/widgets/top_appbar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/widgets/profile_img.dart';
 
 class TopAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String? title;
@@ -66,14 +67,14 @@ class TopAppBarWithButton extends StatelessWidget
 
 class ChatroomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String nickname;
-  final Image logoImage;
+  final String logoUrl;
   @override
   final Size preferredSize = const Size.fromHeight(70);
 
   const ChatroomAppBar({
     super.key,
     required this.nickname,
-    required this.logoImage,
+    required this.logoUrl,
   });
 
   @override
@@ -84,10 +85,15 @@ class ChatroomAppBar extends StatelessWidget implements PreferredSizeWidget {
         children: <Widget>[
           Container(
             margin: const EdgeInsets.all(10),
-            child: CircleAvatar(
-              radius: 35,
-              backgroundImage: logoImage.image,
-            ),
+            child: (logoUrl == '')
+                ? const ProfileImgXSmall(
+                    isLocal: true,
+                    logoUrl: "assets/coffee_bean.png",
+                  )
+                : ProfileImgXSmall(
+                    isLocal: false,
+                    logoUrl: logoUrl,
+                  ),
           ),
           Column(
             mainAxisAlignment: MainAxisAlignment.spaceAround,

--- a/frontend/lib/widgets/top_appbar.dart
+++ b/frontend/lib/widgets/top_appbar.dart
@@ -84,7 +84,7 @@ class ChatroomAppBar extends StatelessWidget implements PreferredSizeWidget {
         mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
           Container(
-            margin: const EdgeInsets.all(10),
+            margin: const EdgeInsets.only(right: 15),
             child: (logoUrl == '')
                 ? const ProfileImgXSmall(
                     isLocal: true,

--- a/frontend/lib/widgets/user_details.dart
+++ b/frontend/lib/widgets/user_details.dart
@@ -26,10 +26,15 @@ class UserDetails extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            ProfileImgMedium(
-              isLocal: true,
-              logoUrl: "assets/$company-logo.png",
-            ),
+            (company == '')
+                ? const ProfileImgMedium(
+                    isLocal: true,
+                    logoUrl: "assets/coffee_bean.png",
+                  )
+                : ProfileImgMedium(
+                    isLocal: true,
+                    logoUrl: "assets/$company-logo.png",
+                  ),
             const SizedBox(
               width: 35,
             ),

--- a/frontend/lib/widgets/user_details.dart
+++ b/frontend/lib/widgets/user_details.dart
@@ -26,7 +26,10 @@ class UserDetails extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            ProfileImg(logo: "assets/$company-logo.png"),
+            ProfileImg(
+              isLocal: true,
+              logoUrl: "assets/$company-logo.png",
+            ),
             const SizedBox(
               width: 35,
             ),

--- a/frontend/lib/widgets/user_details.dart
+++ b/frontend/lib/widgets/user_details.dart
@@ -26,7 +26,7 @@ class UserDetails extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const ProfileImg(logo: "assets/coffee_bean.png"),
+            ProfileImg(logo: "assets/$company-logo.png"),
             const SizedBox(
               width: 35,
             ),

--- a/frontend/lib/widgets/user_details.dart
+++ b/frontend/lib/widgets/user_details.dart
@@ -26,7 +26,7 @@ class UserDetails extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            ProfileImg(
+            ProfileImgMedium(
               isLocal: true,
               logoUrl: "assets/$company-logo.png",
             ),

--- a/frontend/lib/widgets/user_item.dart
+++ b/frontend/lib/widgets/user_item.dart
@@ -82,7 +82,7 @@ class UserItem extends StatelessWidget {
             borderRadius: const BorderRadius.all(Radius.circular(10))),
         child: Row(
           children: [
-            const ProfileImg(logo: "assets/coffee_bean.png"),
+            ProfileImg(logo: "assets/$company-logo.png"),
             Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/frontend/lib/widgets/user_item.dart
+++ b/frontend/lib/widgets/user_item.dart
@@ -82,10 +82,15 @@ class UserItem extends StatelessWidget {
             borderRadius: const BorderRadius.all(Radius.circular(10))),
         child: Row(
           children: [
-            ProfileImgMedium(
-              isLocal: true,
-              logoUrl: "assets/$company-logo.png",
-            ),
+            (company == '')
+                ? const ProfileImgMedium(
+                    isLocal: true,
+                    logoUrl: "assets/coffee_bean.png",
+                  )
+                : ProfileImgMedium(
+                    isLocal: true,
+                    logoUrl: "assets/$company-logo.png",
+                  ),
             Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/frontend/lib/widgets/user_item.dart
+++ b/frontend/lib/widgets/user_item.dart
@@ -82,7 +82,10 @@ class UserItem extends StatelessWidget {
             borderRadius: const BorderRadius.all(Radius.circular(10))),
         child: Row(
           children: [
-            ProfileImg(logo: "assets/$company-logo.png"),
+            ProfileImg(
+              isLocal: true,
+              logoUrl: "assets/$company-logo.png",
+            ),
             Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/frontend/lib/widgets/user_item.dart
+++ b/frontend/lib/widgets/user_item.dart
@@ -82,7 +82,7 @@ class UserItem extends StatelessWidget {
             borderRadius: const BorderRadius.all(Radius.circular(10))),
         child: Row(
           children: [
-            ProfileImg(
+            ProfileImgMedium(
               isLocal: true,
               logoUrl: "assets/$company-logo.png",
             ),


### PR DESCRIPTION
## #️⃣연관된 이슈

> #258 다른 유저 프로필 로고, 커피온도 적용 안되는 현상

## 📝작업 내용

> 모두 적용되게 수정. 
프로필 로고 - 모든 프로필 로고는 ProfileImg 위젯 사용. 카페 유저목록이나 커피챗 요청 목록에서는 로컬의 assets 폴더 내 "[회사명]-logo.png"로 띄움. (유저 정보 가져오는 api에 회사 로고가 없으므로.) 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 추후 백에 api 수정 요청. (cafe/get-users 등의 요청 api 응답에 회사 logoUrl 포함)
