### PR TITLE
#274 match chatroom

### DIFF
--- a/backend/src/main/java/com/coffee/backend/domain/chatroom/controller/ChatroomController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/chatroom/controller/ChatroomController.java
@@ -2,7 +2,6 @@ package com.coffee.backend.domain.chatroom.controller;
 
 import com.coffee.backend.domain.auth.controller.AuthenticationPrincipal;
 import com.coffee.backend.domain.chatroom.dto.ChatroomCreationDto;
-import com.coffee.backend.domain.chatroom.dto.ChatroomResponse;
 import com.coffee.backend.domain.chatroom.dto.ChatroomResponses;
 import com.coffee.backend.domain.chatroom.service.ChatroomService;
 import com.coffee.backend.domain.user.entity.User;
@@ -26,12 +25,12 @@ public class ChatroomController {
 
     //    채팅방 생성 FIXME 체팅방 생성은 api가 아니라 매칭 성공시 서버에 의해 이뤄져야한다
     @PostMapping("/create")
-    public ResponseEntity<ApiResponse<ChatroomResponse>> createChatroom(@AuthenticationPrincipal User user,
-                                                                        @RequestParam("senderId") Long senderId) {
+    public ResponseEntity<ApiResponse<Long>> createChatroom(@AuthenticationPrincipal User user,
+                                                            @RequestParam("senderId") Long senderId) {
         DtoLogger.requestParam("senderId", senderId); // SenderId: 매칭요청을 보낸 사람 Id
 
         ChatroomCreationDto dto = new ChatroomCreationDto(senderId, user.getUserId());
-        ChatroomResponse response = chatroomService.createChatroom(dto);
+        Long response = chatroomService.createChatroom(dto);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/backend/src/main/java/com/coffee/backend/domain/chatroom/controller/ChatroomController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/chatroom/controller/ChatroomController.java
@@ -27,10 +27,10 @@ public class ChatroomController {
     //    채팅방 생성 FIXME 체팅방 생성은 api가 아니라 매칭 성공시 서버에 의해 이뤄져야한다
     @PostMapping("/create")
     public ResponseEntity<ApiResponse<ChatroomResponse>> createChatroom(@AuthenticationPrincipal User user,
-                                                                        @RequestParam("senderUUID") String senderUUID) {
-        DtoLogger.requestParam("senderUUID", senderUUID); // SenderUUID: 매칭요청을 보낸 사람 UUID
+                                                                        @RequestParam("senderId") Long senderId) {
+        DtoLogger.requestParam("senderId", senderId); // SenderId: 매칭요청을 보낸 사람 Id
 
-        ChatroomCreationDto dto = new ChatroomCreationDto(senderUUID, user.getUserId());
+        ChatroomCreationDto dto = new ChatroomCreationDto(senderId, user.getUserId());
         ChatroomResponse response = chatroomService.createChatroom(dto);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/backend/src/main/java/com/coffee/backend/domain/chatroom/dto/ChatroomCreationDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/chatroom/dto/ChatroomCreationDto.java
@@ -6,11 +6,11 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ChatroomCreationDto {
-    private String senderUUID;
+    private Long senderId;
     private Long receiverId;
 
-    public ChatroomCreationDto(String senderUUID, Long receiverId) {
-        this.senderUUID = senderUUID;
+    public ChatroomCreationDto(Long senderId, Long receiverId) {
+        this.senderId = senderId;
         this.receiverId = receiverId;
     }
 }

--- a/backend/src/main/java/com/coffee/backend/domain/chatroom/dto/ChatroomResponse.java
+++ b/backend/src/main/java/com/coffee/backend/domain/chatroom/dto/ChatroomResponse.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class ChatroomResponse {
-    private Long chatrooId;
+    private Long chatroomId;
     private UserDto userInfo;
     private String recentMessage;
 }

--- a/backend/src/main/java/com/coffee/backend/domain/chatroom/service/ChatroomService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/chatroom/service/ChatroomService.java
@@ -34,7 +34,7 @@ public class ChatroomService {
         log.trace("createChatroom()");
 //      TODO?  채팅방 이미 있는지 확인
 //      TODO Exception 수정
-        User sender = userRepository.findByUserUUID(dto.getSenderUUID())
+        User sender = userRepository.findByUserId(dto.getSenderId())
                 .orElseThrow(NoSuchElementException::new);
         User receiver = userRepository.findById(dto.getReceiverId())
                 .orElseThrow(NoSuchElementException::new);

--- a/backend/src/main/java/com/coffee/backend/domain/chatroom/service/ChatroomService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/chatroom/service/ChatroomService.java
@@ -15,6 +15,7 @@ import com.coffee.backend.utils.CustomMapper;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,29 +30,37 @@ public class ChatroomService {
     private final MessageService messageService;
     private final CustomMapper customMapper;
 
+    /**
+     * sender 와 receiver 사이에 기존 채팅방이 있다면 기존 채팅방의 Id, 없다면 새로 생성하고 생성된  채팅방의 Id 반환
+     */
     @Transactional
-    public ChatroomResponse createChatroom(ChatroomCreationDto dto) {
+    public Long createChatroom(ChatroomCreationDto dto) {
         log.trace("createChatroom()");
-//      TODO?  채팅방 이미 있는지 확인
-//      TODO Exception 수정
         User sender = userRepository.findByUserId(dto.getSenderId())
                 .orElseThrow(NoSuchElementException::new);
         User receiver = userRepository.findById(dto.getReceiverId())
                 .orElseThrow(NoSuchElementException::new);
 
-        Chatroom room = new Chatroom();
-        chatroomRepository.save(room);
-        UserChatroom uc1 = new UserChatroom();
-        uc1.setChatroom(room);
-        uc1.setUser(sender);
-        userChatroomRepository.save(uc1);
-        UserChatroom uc2 = new UserChatroom();
-        uc2.setChatroom(room);
-        uc2.setUser(receiver);
-        userChatroomRepository.save(uc2);
-
-        UserDto userInfo = customMapper.toUserDto(sender);
-        return new ChatroomResponse(room.getChatroomId(), userInfo, "");
+        Chatroom room;
+        // 채팅방 이미 있는지 확인
+        Optional<Chatroom> chatroom = userChatroomRepository.findByUserAndOtherUser(sender, receiver);
+        if (chatroom.isPresent()) {
+            // 기존 채팅방 반환
+            room = chatroom.get();
+        } else {
+            // 채팅방 생성
+            room = new Chatroom();
+            chatroomRepository.save(room);
+            UserChatroom uc1 = new UserChatroom();
+            uc1.setChatroom(room);
+            uc1.setUser(sender);
+            userChatroomRepository.save(uc1);
+            UserChatroom uc2 = new UserChatroom();
+            uc2.setChatroom(room);
+            uc2.setUser(receiver);
+            userChatroomRepository.save(uc2);
+        }
+        return room.getChatroomId();
     }
 
     @Transactional

--- a/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
@@ -1,5 +1,6 @@
 package com.coffee.backend.domain.match.controller;
 
+import com.coffee.backend.domain.match.dto.MatchAcceptResponse;
 import com.coffee.backend.domain.match.dto.MatchDto;
 import com.coffee.backend.domain.match.dto.MatchFinishRequestDto;
 import com.coffee.backend.domain.match.dto.MatchIdDto;
@@ -60,11 +61,11 @@ public class MatchController {
     }
 
     @PutMapping("/accept")
-    public ResponseEntity<ApiResponse<MatchDto>> acceptMatchRequest(@RequestBody MatchIdDto dto) {
+    public ResponseEntity<ApiResponse<MatchAcceptResponse>> acceptMatchRequest(@RequestBody MatchIdDto dto) {
         DtoLogger.requestBody(dto);
 
         log.info("Accept Message Catch!!");
-        MatchDto response = matchService.acceptMatchRequest(dto);
+        MatchAcceptResponse response = matchService.acceptMatchRequest(dto);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/backend/src/main/java/com/coffee/backend/domain/match/dto/MatchAcceptResponse.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/dto/MatchAcceptResponse.java
@@ -1,0 +1,17 @@
+package com.coffee.backend.domain.match.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class MatchAcceptResponse {
+    private String matchId;
+    private Long senderId;
+    private Long receiverId;
+    private long expirationTime;
+    private String status;
+    private Long chatroomId;
+}

--- a/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
@@ -1,6 +1,9 @@
 package com.coffee.backend.domain.match.service;
 
+import com.coffee.backend.domain.chatroom.dto.ChatroomCreationDto;
+import com.coffee.backend.domain.chatroom.service.ChatroomService;
 import com.coffee.backend.domain.fcm.service.FcmService;
+import com.coffee.backend.domain.match.dto.MatchAcceptResponse;
 import com.coffee.backend.domain.match.dto.MatchDto;
 import com.coffee.backend.domain.match.dto.MatchFinishRequestDto;
 import com.coffee.backend.domain.match.dto.MatchIdDto;
@@ -44,6 +47,7 @@ public class MatchService {
 
     private static final String LOCK_KEY_PREFIX = "lock:senderId:";
     private final CustomMapper customMapper;
+    private final ChatroomService chatroomService;
 
     // 매칭 요청
     public MatchDto sendMatchRequest(MatchRequestDto dto) {
@@ -148,7 +152,7 @@ public class MatchService {
     }
 
     // 매칭 요청 수락
-    public MatchDto acceptMatchRequest(MatchIdDto dto) {
+    public MatchAcceptResponse acceptMatchRequest(MatchIdDto dto) {
         log.trace("acceptMatchRequest()");
 
         if (!verifyMatchRequest(dto)) {
@@ -167,11 +171,15 @@ public class MatchService {
         User toUser = userRepository.findByUserId(senderId).orElseThrow();
         fcmService.sendPushMessageTo(toUser.getDeviceToken(), "커피챗 매칭 성공", fromUser.getNickname() + "님과 커피챗이 성사되었습니다.");
 
-        MatchDto match = new MatchDto();
+        ChatroomCreationDto chatroomCreationDto = new ChatroomCreationDto(senderId, receiverId);
+        Long chatroomId = chatroomService.createChatroom(chatroomCreationDto);
+
+        MatchAcceptResponse match = new MatchAcceptResponse();
         match.setMatchId(dto.getMatchId());
         match.setSenderId(senderId);
         match.setReceiverId(receiverId);
         match.setStatus("accepted");
+        match.setChatroomId(chatroomId);
 
         redisTemplate.delete("receiverId:" + receiverId + "-senderId:" + senderId);
 

--- a/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
@@ -182,6 +182,8 @@ public class MatchService {
         match.setChatroomId(chatroomId);
 
         redisTemplate.delete("receiverId:" + receiverId + "-senderId:" + senderId);
+        redisTemplate.delete(LOCK_KEY_PREFIX + senderId); // 락 해제
+        redisTemplate.delete(LOCK_KEY_PREFIX + receiverId); // 락 해제
 
         return match;
     }

--- a/backend/src/main/java/com/coffee/backend/domain/userChatroom/repository/UserChatroomRepository.java
+++ b/backend/src/main/java/com/coffee/backend/domain/userChatroom/repository/UserChatroomRepository.java
@@ -29,4 +29,10 @@ public interface UserChatroomRepository extends JpaRepository<UserChatroom, Long
     Optional<UserChatroom> findOtherUserChatroomByChatroomAndUser(@Param("chatroom") Chatroom chatroom,
                                                                   @Param("user") User user);
 
+    @Query("SELECT uc1.chatroom " +
+            "FROM UserChatroom uc1 " +
+            "JOIN UserChatroom uc2 ON uc1.chatroom = uc2.chatroom " +
+            "WHERE uc1.user = :user AND uc2.user = :user2")
+    Optional<Chatroom> findByUserAndOtherUser(User user, User user2);
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #274 

## 📝작업 내용

> 요청 수락시 채팅방 생성 및 아이디 반환

> 이미 채팅방이 존재하면 새로 생성하지 않고 존재하는 채팅방 아이디 반환

> chatroomService의 createChatroom 함수 역할 변경됨
> 기존 : 무조건 새로운 채팅방 생성, 리턴타입 ChatroomResponse
> 변경 : 이미 채팅방이 존재하면 생성하지 않고 존재하는 채팅방 반환, 리턴타입 Long(chatroomId)


### 스크린샷 (선택)

![Screenshot from 2024-05-18 22-46-25](https://github.com/kookmin-sw/capstone-2024-17/assets/84117653/120c061a-156c-498a-9cfb-e104aaf2e20a)


## 💬리뷰 요구사항(선택)

> match/accept 일때 리턴타입 (MatchAcceptResponse) 새로 생성함