### PR TITLE
#291 status

### DIFF
--- a/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
@@ -70,7 +70,7 @@ public class MatchController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @DeleteMapping("/decline")
+    @PutMapping("/decline")
     public ResponseEntity<ApiResponse<MatchDto>> declineMatchRequest(@RequestBody MatchIdDto dto) {
         DtoLogger.requestBody(dto);
 
@@ -79,7 +79,7 @@ public class MatchController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @DeleteMapping("/cancel")
+    @PutMapping("/cancel")
     public ResponseEntity<ApiResponse<MatchDto>> cancelMatchRequest(@RequestBody MatchIdDto dto) {
         DtoLogger.requestBody(dto);
 
@@ -88,7 +88,7 @@ public class MatchController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PostMapping("/finish")
+    @PutMapping("/finish")
     public ResponseEntity<ApiResponse<MatchStatusDto>> finishMatch(@RequestBody MatchFinishRequestDto dto) {
         DtoLogger.requestBody(dto);
 

--- a/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
@@ -1,5 +1,6 @@
 package com.coffee.backend.domain.match.controller;
 
+import com.coffee.backend.domain.match.dto.IsMatchingDto;
 import com.coffee.backend.domain.match.dto.MatchAcceptResponse;
 import com.coffee.backend.domain.match.dto.MatchDto;
 import com.coffee.backend.domain.match.dto.MatchFinishRequestDto;
@@ -13,12 +14,10 @@ import com.coffee.backend.domain.match.entity.Review;
 import com.coffee.backend.domain.match.service.MatchService;
 import com.coffee.backend.global.DtoLogger;
 import com.coffee.backend.utils.ApiResponse;
-import com.google.protobuf.Api;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -97,21 +96,21 @@ public class MatchController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-//    @GetMapping("/isMatching")
-//    public ResponseEntity<ApiResponse<MatchStatusDto>> isMatching(@RequestParam Long userId) {
-//        DtoLogger.requestParam("userId", userId);
-//
-//        log.info("Check if isMathing");
-//        MatchStatusDto response = matchService.isMatching(userId);
-//        return ResponseEntity.ok(ApiResponse.success(response));
-//    }
-
     @PutMapping("/alert/expired")
     public ResponseEntity<ApiResponse<MatchStatusDto>> alertExpired(@RequestBody MatchIdDto dto) {
         DtoLogger.requestBody(dto);
-        log.info("Set the match expired");
 
+        log.info("Set the match expired");
         MatchStatusDto response = matchService.setExpired(dto);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/isMatching")
+    public ResponseEntity<ApiResponse<IsMatchingDto>> isMatching(@RequestParam Long userId) {
+        DtoLogger.requestParam("userId", userId);
+
+        log.info("Check if isMathing");
+        IsMatchingDto response = matchService.isMatching(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
@@ -96,17 +96,8 @@ public class MatchController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PutMapping("/alert/expired")
-    public ResponseEntity<ApiResponse<MatchStatusDto>> alertExpired(@RequestBody MatchIdDto dto) {
-        DtoLogger.requestBody(dto);
-
-        log.info("Set the match expired");
-        MatchStatusDto response = matchService.setExpired(dto);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
     @GetMapping("/isMatching")
-    public ResponseEntity<ApiResponse<IsMatchingDto>> isMatching(@RequestParam Long userId) {
+    public ResponseEntity<ApiResponse<IsMatchingDto>> isMatching(@RequestParam("userId") Long userId) {
         DtoLogger.requestParam("userId", userId);
 
         log.info("Check if isMathing");

--- a/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
@@ -13,6 +13,7 @@ import com.coffee.backend.domain.match.entity.Review;
 import com.coffee.backend.domain.match.service.MatchService;
 import com.coffee.backend.global.DtoLogger;
 import com.coffee.backend.utils.ApiResponse;
+import com.google.protobuf.Api;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,11 +98,20 @@ public class MatchController {
     }
 
     @GetMapping("/isMatching")
-    public ResponseEntity<ApiResponse<MatchStatusDto>> isMatching(@RequestBody MatchIdDto dto) {
-        DtoLogger.requestBody(dto);
+    public ResponseEntity<ApiResponse<MatchStatusDto>> isMatching(@RequestParam Long userId) {
+        DtoLogger.requestParam("userId", userId);
 
         log.info("Check if isMathing");
-        MatchStatusDto response = matchService.isMatching(dto);
+        MatchStatusDto response = matchService.isMatching(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/alert/expired")
+    public ResponseEntity<ApiResponse<MatchStatusDto>> alertExpired(@RequestBody MatchIdDto dto) {
+        DtoLogger.requestBody(dto);
+        log.info("Set the match expired");
+
+        MatchStatusDto response = matchService.setExpired(dto);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/controller/MatchController.java
@@ -97,14 +97,14 @@ public class MatchController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @GetMapping("/isMatching")
-    public ResponseEntity<ApiResponse<MatchStatusDto>> isMatching(@RequestParam Long userId) {
-        DtoLogger.requestParam("userId", userId);
-
-        log.info("Check if isMathing");
-        MatchStatusDto response = matchService.isMatching(userId);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
+//    @GetMapping("/isMatching")
+//    public ResponseEntity<ApiResponse<MatchStatusDto>> isMatching(@RequestParam Long userId) {
+//        DtoLogger.requestParam("userId", userId);
+//
+//        log.info("Check if isMathing");
+//        MatchStatusDto response = matchService.isMatching(userId);
+//        return ResponseEntity.ok(ApiResponse.success(response));
+//    }
 
     @PutMapping("/alert/expired")
     public ResponseEntity<ApiResponse<MatchStatusDto>> alertExpired(@RequestBody MatchIdDto dto) {

--- a/backend/src/main/java/com/coffee/backend/domain/match/dto/IsMatchingDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/dto/IsMatchingDto.java
@@ -1,0 +1,10 @@
+package com.coffee.backend.domain.match.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IsMatchingDto {
+    String isMatching;
+}

--- a/backend/src/main/java/com/coffee/backend/domain/match/dto/MatchDto.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/dto/MatchDto.java
@@ -9,6 +9,6 @@ public class MatchDto {
     private String matchId;
     private Long senderId;
     private Long receiverId;
-    private long expirationTime;
+    private String expirationTime;
     private String status;
 }

--- a/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
@@ -169,8 +169,8 @@ public class MatchService {
         Long senderId = getLongId(redisTemplate.opsForHash().get(key, "senderId"));
         Long receiverId = getLongId(redisTemplate.opsForHash().get(key, "receiverId"));
 
-        ChatroomCreationDto chatroomCreationDto = new ChatroomCreationDto(senderId, receiverId);
-        Long chatroomId = chatroomService.createChatroom(chatroomCreationDto);
+//        ChatroomCreationDto chatroomCreationDto = new ChatroomCreationDto(senderId, receiverId);
+//        Long chatroomId = chatroomService.createChatroom(chatroomCreationDto);
 
         redisTemplate.opsForHash().put(key, "status", "accepted");
         redisTemplate.opsForHash().put("receiverId:" + receiverId + "-senderId:" + senderId, "status", "accepted");
@@ -199,7 +199,7 @@ public class MatchService {
         match.setSenderId(senderId);
         match.setReceiverId(receiverId);
         match.setStatus("accepted");
-        match.setChatroomId(chatroomId);
+//        match.setChatroomId(chatroomId);
 
         return match;
     }
@@ -208,7 +208,7 @@ public class MatchService {
     private void validateIfAlreadyAccepted(String matchId) {
         log.trace("validateIfAlreadyAccepted()");
 
-        String status = (String) redisTemplate.opsForHash().get("matchId:" + matchId + "-info", "status");
+        String status = (String) redisTemplate.opsForHash().get("matchId:" + matchId, "status");
         if (status != null && status.equals("accepted")) {
             throw new CustomException(ErrorCode.REQUEST_ALREADY_ACCEPTED);
         }
@@ -217,9 +217,7 @@ public class MatchService {
     // 매칭 요청 거절
     public MatchDto declineMatchRequest(MatchIdDto dto) {
         log.trace("declineMatchRequest()");
-
-        validateTTL(dto.getMatchId());
-
+        
         String key = "matchId:" + dto.getMatchId();
         Long senderId = getLongId(redisTemplate.opsForHash().get(key, "senderId"));
         Long receiverId = getLongId(redisTemplate.opsForHash().get(key, "receiverId"));
@@ -230,8 +228,8 @@ public class MatchService {
         fcmService.sendPushMessageTo(toUser.getDeviceToken(), "커피챗 매칭 실패",
                 fromUser.getNickname() + "님이 커피챗 요청을 거절하였습니다.");
 
-        redisTemplate.delete(key);
-        redisTemplate.delete("receiverId:" + receiverId + "-senderId:" + senderId);
+        redisTemplate.opsForHash().put(key, "status", "declined");
+        redisTemplate.opsForHash().put("receiverId:" + receiverId + "-senderId:" + senderId, "status", "declined");
         redisTemplate.delete(LOCK_KEY_PREFIX + senderId); // 락 해제
 
         MatchDto match = new MatchDto();
@@ -246,7 +244,7 @@ public class MatchService {
     public MatchDto cancelMatchRequest(MatchIdDto dto) {
         log.trace("cancelMatchRequest()");
 
-        validateTTL(dto.getMatchId());
+//        validateTTL(dto.getMatchId());
 
         String key = "matchId:" + dto.getMatchId();
         Long senderId = getLongId(redisTemplate.opsForHash().get(key, "senderId"));

--- a/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
@@ -217,7 +217,9 @@ public class MatchService {
     // 매칭 요청 거절
     public MatchDto declineMatchRequest(MatchIdDto dto) {
         log.trace("declineMatchRequest()");
-        
+
+//        validateTTL(dto.getMatchId());
+
         String key = "matchId:" + dto.getMatchId();
         Long senderId = getLongId(redisTemplate.opsForHash().get(key, "senderId"));
         Long receiverId = getLongId(redisTemplate.opsForHash().get(key, "receiverId"));
@@ -250,8 +252,8 @@ public class MatchService {
         Long senderId = getLongId(redisTemplate.opsForHash().get(key, "senderId"));
         Long receiverId = getLongId(redisTemplate.opsForHash().get(key, "receiverId"));
 
-        redisTemplate.delete(key);
-        redisTemplate.delete("receiverId:" + receiverId + "-senderId:" + senderId);
+        redisTemplate.opsForHash().put(key, "status", "declined");
+        redisTemplate.opsForHash().put("receiverId:" + receiverId + "-senderId:" + senderId, "status", "canceled");
         redisTemplate.delete(LOCK_KEY_PREFIX + senderId); // 락 해제
 
         MatchDto match = new MatchDto();

--- a/backend/src/main/java/com/coffee/backend/exception/ErrorCode.java
+++ b/backend/src/main/java/com/coffee/backend/exception/ErrorCode.java
@@ -31,10 +31,12 @@ public enum ErrorCode {
     REQUEST_DUPLICATED(HttpStatus.CONFLICT, "7409", "요청이 중복됩니다."),
     REQUEST_SAME_USER(HttpStatus.CONFLICT, "7409", "본인에게 요청을 보낼 수 없습니다."),
     REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "7404", "해당 요청 정보를 찾을 수 없습니다."),
-    REQUEST_EXPIRED(HttpStatus.UNAUTHORIZED, "7401", "요청이 만료되었습니다."),
     REQUEST_ALREADY_ACCEPTED(HttpStatus.CONFLICT, "7409", "이미 수락한 요청입니다."),
-    REQUEST_ALREADY_FINISHED(HttpStatus.CONFLICT, "7409", "이미 종료한 요청입니다."),
     REQUEST_NOT_ACCEPTED(HttpStatus.NOT_FOUND, "7404", "해당 요청은 수락되지 않았습니다."),
+    REQUEST_DECLINED(HttpStatus.CONFLICT, "7409", "이미 거절된 요청입니다."),
+    REQUEST_CANCELED(HttpStatus.CONFLICT, "7409", "이미 취소된 요청입니다."),
+    REQUEST_FINISHED(HttpStatus.CONFLICT, "7409", "이미 종료된 요청입니다."),
+    REQUEST_EXPIRED(HttpStatus.UNAUTHORIZED, "7401", "요청이 만료되었습니다."),
 
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "8404", "해당 COMPANY를 찾을 수 없습니다."),
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #291 

## 📝작업 내용

Redis 저장 형태가 달라짐에 따라 매칭 요청/수락/거절/종료 등의 매칭 관련 API 로직을 전격 리팩토링

## 💬리뷰 요구사항(선택)

- 요청(match/request)을 제외한 수락(match/accept), 거절(match/decline), 취소(match/cancel), 종료(match/finish) API의 메소드가 PUT으로 변경됨
- match/isMatching의 response가 "yes" / "no" (String) 으로 변경됨

![image](https://github.com/kookmin-sw/capstone-2024-17/assets/119438312/96a52152-0351-4ef5-a1ae-f26c26352b9e)
