### PR TITLE
hotfix-kakao

### DIFF
--- a/backend/src/main/java/com/coffee/backend/domain/auth/service/KakaoLoginService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/auth/service/KakaoLoginService.java
@@ -2,6 +2,7 @@ package com.coffee.backend.domain.auth.service;
 
 import com.coffee.backend.domain.auth.dto.AuthDto;
 import com.coffee.backend.domain.auth.dto.KakaoUserInfoDto;
+import com.coffee.backend.domain.user.entity.Position;
 import com.coffee.backend.domain.user.entity.User;
 import com.coffee.backend.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,6 +58,9 @@ public class KakaoLoginService {
         // DB에 정보 없으면 회원가입 처리
         if (user.getKakaoId() == null) {
             user.setKakaoId(dto.getId());
+            user.setNickname("user@" + dto.getId());
+            user.setPosition(Position.P00);
+            user.setCoffeeBean(46);
             userRepository.save(user);
         }
 

--- a/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/match/service/MatchService.java
@@ -127,6 +127,7 @@ public class MatchService {
                 ReceiverInfoDto receiverInfo = mapper.map(receiver, ReceiverInfoDto.class);
                 receiverInfo.setReceiverId(receiverId);
                 receiverInfo.setCompany(customMapper.toCompanyDto(receiver.getCompany()));
+                receiverInfo.setPosition(receiver.getPosition().getName());
 
                 MatchInfoResponseDto res = new MatchInfoResponseDto();
                 res.setMatchId(matchId);
@@ -161,6 +162,7 @@ public class MatchService {
                 SenderInfoDto senderInfo = mapper.map(sender, SenderInfoDto.class);
                 senderInfo.setSenderId(senderId);
                 senderInfo.setCompany(customMapper.toCompanyDto(sender.getCompany()));
+                senderInfo.setPosition(sender.getPosition().getName());
 
                 MatchReceivedInfoDto res = new MatchReceivedInfoDto();
                 res.setMatchId(matchId);
@@ -420,9 +422,11 @@ public class MatchService {
         SenderInfoDto senderInfo = mapper.map(sender, SenderInfoDto.class);
         senderInfo.setSenderId(senderId);
         senderInfo.setCompany(customMapper.toCompanyDto(sender.getCompany()));
+        senderInfo.setPosition(sender.getPosition().getName());
         ReceiverInfoDto receiverInfo = mapper.map(receiver, ReceiverInfoDto.class);
         receiverInfo.setReceiverId(receiverId);
         receiverInfo.setCompany(customMapper.toCompanyDto(receiver.getCompany()));
+        receiverInfo.setPosition(receiver.getPosition().getName());
 
         IsMatchingDto response = mapper.map(isMatchingInfo, IsMatchingDto.class);
         response.setSenderInfo(senderInfo);

--- a/backend/src/main/java/com/coffee/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.coffee.backend.domain.user.controller;
 
 import com.coffee.backend.domain.auth.controller.AuthenticationPrincipal;
 import com.coffee.backend.domain.user.dto.IntroductionUpdateRequest;
+import com.coffee.backend.domain.user.dto.NicknameUpdateRequest;
 import com.coffee.backend.domain.user.dto.PositionUpdateRequest;
 import com.coffee.backend.domain.user.dto.UserDto;
 import com.coffee.backend.domain.user.entity.Position;
@@ -27,6 +28,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+
+    @PostMapping("/nickname/update")
+    public ResponseEntity<ApiResponse<UserDto>> nickname(@AuthenticationPrincipal User user,
+                                                         @RequestBody NicknameUpdateRequest dto) {
+        DtoLogger.requestBody(dto);
+        
+        return ResponseEntity.ok(ApiResponse.success(userService.updateUserNickname(user, dto.getNickname())));
+    }
 
     @PostMapping("/position/update")
     public ResponseEntity<ApiResponse<UserDto>> position(@AuthenticationPrincipal User user,

--- a/backend/src/main/java/com/coffee/backend/domain/user/dto/NicknameUpdateRequest.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/dto/NicknameUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.coffee.backend.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NicknameUpdateRequest {
+    private String nickname;
+}

--- a/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/coffee/backend/domain/user/service/UserService.java
@@ -77,6 +77,12 @@ public class UserService {
         user.setCompany(company);
         userRepository.save(user);
     }
+    
+    public UserDto updateUserNickname(User user, String nickname) {
+        log.trace("updateUserNickname()");
+        user.setNickname(nickname);
+        return customMapper.toUserDto(userRepository.save(user));
+    }
 
     public UserDto updateUserPosition(User user, String position) {
         log.trace("updateUserPosition()");


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #336, resolve #326, resolve #339

## 📝작업 내용

> 카카오 회원가입할 때 닉네임, 직무 값 넣어줌

> 매칭 정보 받을 때 직무 getName()으로 제대로 보내주기

> 닉네임 변경 api 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
