### PR TITLE
[feat] 요청 확인 시 받은 요청 탭으로 이동 #376

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -289,6 +289,7 @@ class _MyHomePageState extends State<MyHomePage> {
               onTap: (index) {
                 selectedIndexProvider.selectedIndex = index;
                 if (index == 1) {
+                  selectedIndexProvider.selectedTabIndex = 0; // 보낸 요청 탭으로
                   // 커피챗 매칭정보 가져오기
                   getUserDetail().then((userDetail) {
                     getMatchingInfo(userDetail["data"]["userId"]).then((value) {

--- a/frontend/lib/model/selected_index_model.dart
+++ b/frontend/lib/model/selected_index_model.dart
@@ -2,11 +2,18 @@ import 'package:flutter/material.dart';
 
 class SelectedIndexModel extends ChangeNotifier {
   int _selectedIndex = 0;
+  int _selectedTabIndex = 0;
 
   int get selectedIndex => _selectedIndex;
+  int get selectedTabIndex => _selectedTabIndex;
 
   set selectedIndex(int index) {
     _selectedIndex = index;
+    notifyListeners();
+  }
+
+  set selectedTabIndex(int index) {
+    _selectedTabIndex = index;
     notifyListeners();
   }
 }

--- a/frontend/lib/screen/coffeechat_req_list.dart
+++ b/frontend/lib/screen/coffeechat_req_list.dart
@@ -74,6 +74,7 @@ class CoffeechatReqList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final matchingInfo = Provider.of<MatchingInfoModel>(context);
+    final selectedIndexProvider = Provider.of<SelectedIndexModel>(context);
 
     return (matchingInfo.isMatching == true)
         ? Matching(
@@ -85,9 +86,10 @@ class CoffeechatReqList extends StatelessWidget {
             partnerCompany: matchingInfo.partnerCompany!,
             partnerNickname: matchingInfo.partnerNickname!,
           )
-        : const DefaultTabController(
+        : DefaultTabController(
+            initialIndex: selectedIndexProvider.selectedTabIndex,
             length: 2,
-            child: Scaffold(
+            child: const Scaffold(
               appBar: TopAppBar(
                 title: "커피챗 요청 목록",
               ),

--- a/frontend/lib/widgets/dialog/notification_dialog.dart
+++ b/frontend/lib/widgets/dialog/notification_dialog.dart
@@ -18,6 +18,7 @@ class ArriveRequestNotification extends StatelessWidget {
       handleNavigate: () {
         Navigator.of(context).popUntil(ModalRoute.withName('/'));
         selectedIndexProvider.selectedIndex = 1;
+        selectedIndexProvider.selectedTabIndex = 1;
       },
     );
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #376

## 📝작업 내용

> 요청 도착 알림에서 요청 보기 버튼을 클릭했을 때 보낸 요청 탭 말고 받은 요청 탭으로 이동하게 함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> tab index를 프로바이더에 추가했음
> 이미 요청 페이지에 위치하고 있는 경우에는 받은 요청 탭으로 이동되지 않음... 왜지
