### PR TITLE
[fix] 새로 추가된 카페에 대해서만 sub #378

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -132,27 +132,34 @@ class _MyHomePageState extends State<MyHomePage> {
   late StompClient stompClient;
 
   late UserProfileModel userProfile;
-  late List<String> cafeList; // 주변 카페 리스트
+  List<String>? cafeList; // 주변 카페 리스트
   late AllUsersModel allUsers;
   late MatchingInfoModel matchingInfo; // 커피챗 진행중 정보
 
   late final List<Widget> _screenOptions;
 
-  void updateCafeList(List<String> cafeList) {
+  void updateCafeList(List<String> newCafeList) {
+    List<String> subList = newCafeList; // sub할 카페 리스트
+
+    if (cafeList != null) {
+      // 반경에 새롭게 들어온 카페만 sub할 리스트에 추가
+      subList = newCafeList.where((cafe) => !cafeList!.contains(cafe)).toList();
+    }
+
     setState(() {
-      this.cafeList = cafeList;
+      cafeList = newCafeList;
     });
 
     // 로그인된 상태이면 - 유저 목록 post, sub 요청
     if (userToken != null) {
       // http post 요청
-      getAllUsers(userToken!, cafeList, userProfile.userId!).then((value) {
+      getAllUsers(userToken!, newCafeList, userProfile.userId!).then((value) {
         allUsers.setAllUsers(value);
 
         // 주변 모든 카페에 sub 요청
         subCafeList(
           stompClient: stompClient,
-          cafeList: cafeList,
+          cafeList: subList,
           allUsers: allUsers,
           userId: userProfile.userId!,
         );


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #378 카페 지정 시 여러 개 중복해서 들어가는 현상

## 📝작업 내용

> 저번에 해결된 줄 알았으나 아니었음. 
하나의 카페에 대해 여러 번 구독이 일어나서 생기는 문제로 보여서 중복 구독하지 않도록 코드 수정.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
