### PR TITLE
#394 later finish

### DIFF
--- a/frontend/lib/notification.dart
+++ b/frontend/lib/notification.dart
@@ -3,6 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/model/matching_info_model.dart';
+import 'package:frontend/model/user_profile_model.dart';
 import 'package:frontend/service/api_service.dart';
 import 'package:frontend/widgets/dialog/notification_dialog.dart';
 import 'package:frontend/widgets/user/user_details.dart';
@@ -99,7 +100,9 @@ class FCM {
           showDialog(
             context: context,
             builder: (BuildContext context) {
-              return ReqFinishedNotification(nickname: nickname);
+              return ReqFinishedNotification(
+                nickname: nickname,
+              );
             },
           );
         }

--- a/frontend/lib/screen/coffeechat_rating_screen.dart
+++ b/frontend/lib/screen/coffeechat_rating_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/model/matching_info_model.dart';
 import 'package:frontend/model/selected_index_model.dart';
 import 'package:frontend/service/api_service.dart';
 import 'package:frontend/widgets/dialog/one_button_dialog.dart';
@@ -37,6 +38,8 @@ class _CoffeeChatRatingState extends State<CoffeeChatRating> {
   @override
   Widget build(BuildContext context) {
     final selectedIndexProvider = Provider.of<SelectedIndexModel>(context);
+    final matchingInfo = Provider.of<MatchingInfoModel>(context);
+
     return Scaffold(
       backgroundColor: const Color(0xFFF09676), // 배경색 설정
       body: Center(
@@ -116,12 +119,13 @@ class _CoffeeChatRatingState extends State<CoffeeChatRating> {
                         Map<String, dynamic> review =
                             await checkReviewedRequest(
                                 widget.matchId, widget.userId);
-                        if (res['isMatching'] != 'no') {
-                          // if (review['data']['hasReviewed'] == true) {
-                          //상대방이 리뷰를 남긴 경우에만 finish 가능 (중복 종료 요청 방지)
+
+                        // 커피챗 진행중인 경우에만 종료 요청
+                        if (matchingInfo.isMatching) {
                           await matchFinishRequest(
-                              widget.matchId, widget.userId);
-                          // }
+                            widget.matchId,
+                            widget.userId,
+                          );
                         }
 
                         showDialog(

--- a/frontend/lib/screen/coffeechat_rating_screen.dart
+++ b/frontend/lib/screen/coffeechat_rating_screen.dart
@@ -4,8 +4,6 @@ import 'package:frontend/model/selected_index_model.dart';
 import 'package:frontend/service/api_service.dart';
 import 'package:frontend/widgets/dialog/one_button_dialog.dart';
 import 'package:provider/provider.dart';
-import 'map_place.dart';
-import 'package:flutter/material.dart';
 
 class CoffeeChatRating extends StatefulWidget {
   final String partnerNickname;
@@ -113,12 +111,8 @@ class _CoffeeChatRatingState extends State<CoffeeChatRating> {
 
                         print(response);
 
-                        Map<String, dynamic> res =
-                            await getMatchingInfo(widget.userId);
-
-                        Map<String, dynamic> review =
-                            await checkReviewedRequest(
-                                widget.matchId, widget.userId);
+                        await checkReviewedRequest(
+                            widget.matchId, widget.userId);
 
                         // 커피챗 진행중인 경우에만 종료 요청
                         if (matchingInfo.isMatching) {

--- a/frontend/lib/widgets/dialog/notification_dialog.dart
+++ b/frontend/lib/widgets/dialog/notification_dialog.dart
@@ -68,14 +68,15 @@ class ReqFinishedNotification extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final selectedIndexProvider = Provider.of<SelectedIndexModel>(context);
-    return NotificationDialog(
-        contents: '$nickname님이 커피챗을 \n종료했어요!',
-        backButton: "닫기",
-        navigateButton: "종료하기",
-        handleNavigate: () {
-          Navigator.of(context).popUntil(ModalRoute.withName('/'));
-          selectedIndexProvider.selectedIndex = 1;
-        });
+    return NotificationDialogLong(
+      title: "커피챗 종료",
+      contents: '$nickname님이 커피챗을 \n종료했어요!',
+      button: "확인",
+      handlePressedButton: () {
+        Navigator.of(context).popUntil(ModalRoute.withName('/'));
+        selectedIndexProvider.selectedIndex = 1;
+      },
+    );
   }
 }
 
@@ -171,12 +172,14 @@ class NotificationDialogLong extends StatelessWidget {
   final String title;
   final String contents;
   final String button;
+  final Function? handlePressedButton;
 
   const NotificationDialogLong({
     super.key,
     required this.title,
     required this.contents,
     required this.button,
+    this.handlePressedButton,
   });
 
   @override
@@ -225,6 +228,7 @@ class NotificationDialogLong extends StatelessWidget {
                   text: button,
                   handlePressed: () {
                     Navigator.of(context).pop();
+                    if (handlePressedButton != null) handlePressedButton!();
                   },
                 )
               ],

--- a/frontend/lib/widgets/dialog/notification_dialog.dart
+++ b/frontend/lib/widgets/dialog/notification_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/model/matching_info_model.dart';
 import 'package:frontend/model/selected_index_model.dart';
 import 'package:frontend/screen/coffeechat_rating_screen.dart';
+import 'package:frontend/service/api_service.dart';
 import 'package:frontend/widgets/button/bottom_two_buttons.dart';
 import 'package:frontend/widgets/button/modal_button.dart';
 import 'package:provider/provider.dart';
@@ -35,11 +36,33 @@ class ReqAcceptedNotification extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final selectedIndexProvider = Provider.of<SelectedIndexModel>(context);
+    final matchingInfo = Provider.of<MatchingInfoModel>(context);
+
     return NotificationDialog(
         contents: '$nickname님이 커피챗 요청을 \n수락했어요!',
         backButton: "닫기",
         navigateButton: "채팅 보기",
         handleNavigate: () {
+          // 커피챗 매칭정보 업데이트
+          getUserDetail().then((userDetail) {
+            getMatchingInfo(userDetail["data"]["userId"]).then((value) {
+              // 커피챗 진행중 여부 저장 - true
+              matchingInfo.setIsMatching(value["isMatching"]);
+
+              if (value["isMatching"]) {
+                matchingInfo.setMatching(
+                  matchId: value["matchId"],
+                  myId: value["myId"],
+                  myNickname: value["myNickname"],
+                  myCompany: value["myCompany"],
+                  partnerId: value["partnerId"],
+                  partnerCompany: value["partnerCompany"],
+                  partnerNickname: value["partnerNickname"],
+                );
+              }
+            });
+          });
+
           Navigator.of(context).popUntil(ModalRoute.withName('/'));
           selectedIndexProvider.selectedIndex = 2;
         });

--- a/frontend/lib/widgets/dialog/notification_dialog.dart
+++ b/frontend/lib/widgets/dialog/notification_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/model/matching_info_model.dart';
 import 'package:frontend/model/selected_index_model.dart';
+import 'package:frontend/screen/coffeechat_rating_screen.dart';
 import 'package:frontend/widgets/button/bottom_two_buttons.dart';
 import 'package:frontend/widgets/button/modal_button.dart';
 import 'package:provider/provider.dart';
@@ -63,18 +65,36 @@ class ReqDeniedNotification extends StatelessWidget {
 class ReqFinishedNotification extends StatelessWidget {
   final String nickname;
 
-  const ReqFinishedNotification({super.key, required this.nickname});
+  const ReqFinishedNotification({
+    super.key,
+    required this.nickname,
+  });
 
   @override
   Widget build(BuildContext context) {
     final selectedIndexProvider = Provider.of<SelectedIndexModel>(context);
+    final matchingInfo = Provider.of<MatchingInfoModel>(context);
+
     return NotificationDialogLong(
       title: "커피챗 종료",
       contents: '$nickname님이 커피챗을 \n종료했어요!',
       button: "확인",
       handlePressedButton: () {
-        Navigator.of(context).popUntil(ModalRoute.withName('/'));
-        selectedIndexProvider.selectedIndex = 1;
+        // 커피챗 진행중 여부 저장 - false
+        matchingInfo.setIsMatching(false);
+
+        // 커피챗 평가 화면으로 이동
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => CoffeeChatRating(
+              userId: matchingInfo.myId!,
+              partnerId: matchingInfo.partnerId!,
+              partnerNickname: matchingInfo.partnerNickname!,
+              matchId: matchingInfo.matchId!,
+            ),
+          ),
+        );
       },
     );
   }

--- a/frontend/lib/widgets/dialog/notification_dialog.dart
+++ b/frontend/lib/widgets/dialog/notification_dialog.dart
@@ -239,7 +239,7 @@ class NotificationDialogLong extends StatelessWidget {
             top: -50,
             left: 110,
             child: Image.asset(
-              'assets/logo.png',
+              'assets/logo_no_background.png',
               width: 80,
             ),
           ),


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #394 커피챗 종료 알림 받은 후 종료 처리

## 📝작업 내용

>  커피챗 매칭된 순간 matchingInfoModel 업데이트,
 커피챗 종료 알림 받으면 isMatching = false로 업데이트 후 커피챗 평가화면으로 이동,
 matchFinishRequest 호출 시 조건문 matchingInfo 프로바이더 사용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
